### PR TITLE
docs: rename references to hai-agents-python

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ behavior:
 ## Dev setup
 
 ```bash
-git clone https://github.com/hcompai/agent-api && cd agent-api
+git clone https://github.com/hcompai/hai-agents-python && cd hai-agents-python
 uv sync --group dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
 </p>
 
-# agent-api
+# hai-agents-python
 
-Developer-facing libraries and tools for [H Company's Agent Platform](https://hcompany.ai).
+Python developer libraries and tools for [H Company's Agent Platform](https://hcompany.ai). The TypeScript counterpart lives in [`hai-agents-ts`](https://github.com/hcompai/hai-agents-ts).
 
 ## Packages
 


### PR DESCRIPTION
Repo was renamed `agent-api` -> `hai-agents-python`. Updates the two in-repo self-references (root README heading, CONTRIBUTING clone URL) and links the forthcoming `hai-agents-ts` sibling.

Cross-repo dispatch target in `agent_platform` is handled in a separate PR. The Python package name (`agent-platform`) is intentionally unchanged here; renaming the published package is a separate, breaking decision.

Made with [Cursor](https://cursor.com)