### PR TITLE
chore(sdk): sync to agent_platform@3b0d87c (v0.1.0)

### DIFF
--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-platform"
-version = "0.0.0"
+version = "0.1.0"
 description = "Python SDK for H Company's Agent Platform"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/packages/sdk/src/agent_platform/__init__.py
+++ b/packages/sdk/src/agent_platform/__init__.py
@@ -1,0 +1,115 @@
+"""H Company Agent Platform — Python SDK.
+
+This module is the hand-written entry point. The rest of the package
+(``api/``, ``models/``, ``client.py``, etc.) is generated from
+``openapi.json`` by ``openapi-python-client==0.28.3``.
+
+Do NOT edit ``packages/sdk/src/agent_platform/__init__.py`` directly — it
+is overwritten on every regen. Edit ``templates/__init__.py.static``
+instead; the schema-sync workflow restores it after each regeneration.
+"""
+
+from __future__ import annotations
+
+from agent_platform.client import AuthenticatedClient as _AuthenticatedClient
+from agent_platform.models.agent import Agent
+from agent_platform.models.agent_record import AgentRecord
+from agent_platform.models.browser import Browser
+from agent_platform.models.code_sandbox import CodeSandbox
+from agent_platform.models.create_agent import CreateAgent
+from agent_platform.models.create_environment import CreateEnvironment
+from agent_platform.models.create_memory import CreateMemory
+from agent_platform.models.create_skill import CreateSkill
+from agent_platform.models.environment_record import EnvironmentRecord
+from agent_platform.models.mcp import MCP
+from agent_platform.models.memory import Memory
+from agent_platform.models.memory_record import MemoryRecord
+from agent_platform.models.session import Session
+from agent_platform.models.session_request import SessionRequest
+from agent_platform.models.session_summary import SessionSummary
+from agent_platform.models.skill import Skill
+from agent_platform.models.skill_record import SkillRecord
+from agent_platform.models.update_environment import UpdateEnvironment
+from agent_platform.models.update_memory import UpdateMemory
+from agent_platform.models.update_skill import UpdateSkill
+
+__all__ = [
+    "Client",
+    "AsyncClient",
+    # Agent
+    "Agent",
+    "AgentRecord",
+    "CreateAgent",
+    # Environment specs (discriminated union members)
+    "Browser",
+    "CodeSandbox",
+    "MCP",
+    "Memory",
+    # Environment catalog
+    "EnvironmentRecord",
+    "CreateEnvironment",
+    "UpdateEnvironment",
+    # Skill
+    "Skill",
+    "SkillRecord",
+    "CreateSkill",
+    "UpdateSkill",
+    # Memory catalog
+    "MemoryRecord",
+    "CreateMemory",
+    "UpdateMemory",
+    # Session
+    "Session",
+    "SessionRequest",
+    "SessionSummary",
+]
+
+
+class Client(_AuthenticatedClient):
+    """Sync Agent Platform SDK client.
+
+    Args:
+        api_key: Portal-H API key (``hk-*`` format). Sent as
+            ``Authorization: Bearer <api_key>`` on every request.
+        base_url: AgP base URL. Defaults to production.
+
+    Example:
+        >>> from agent_platform import Client
+        >>> client = Client(api_key="hk-...", base_url="https://agp.hcompany.ai")
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str = "https://agp.hcompany.ai",
+    ) -> None:
+        super().__init__(base_url=base_url, token=api_key)
+
+
+class AsyncClient(_AuthenticatedClient):
+    """Async Agent Platform SDK client.
+
+    Same constructor as ``Client``. Use with ``asyncio``-flavoured endpoint
+    functions (``asyncio()`` / ``asyncio_detailed()`` in each ``agent_platform.api.*`` module).
+
+    Note: openapi-python-client 0.28.x does not generate separate sync/async
+    *client* classes — it generates per-endpoint sync and async *functions* that
+    both accept an ``AuthenticatedClient`` instance. ``Client`` and ``AsyncClient``
+    here are the same underlying class, exposed under two names for ergonomic
+    discoverability (so users can write `from agent_platform import AsyncClient`).
+
+    Example:
+        >>> from agent_platform import AsyncClient
+        >>> from agent_platform.api.sessions import list_session_events
+        >>> client = AsyncClient(api_key="hk-...")
+        >>> events = await list_session_events.asyncio(client=client, id="…")
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str = "https://agp.hcompany.ai",
+    ) -> None:
+        super().__init__(base_url=base_url, token=api_key)

--- a/packages/sdk/src/agent_platform/api/__init__.py
+++ b/packages/sdk/src/agent_platform/api/__init__.py
@@ -1,0 +1,1 @@
+"""Contains methods for accessing the API"""

--- a/packages/sdk/src/agent_platform/api/agents/__init__.py
+++ b/packages/sdk/src/agent_platform/api/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/packages/sdk/src/agent_platform/api/agents/create_agent.py
+++ b/packages/sdk/src/agent_platform/api/agents/create_agent.py
@@ -1,0 +1,175 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.agent_record import AgentRecord
+from ...models.create_agent import CreateAgent
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    *,
+    body: CreateAgent,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v2/agents",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> AgentRecord | HTTPValidationError | None:
+    if response.status_code == 201:
+        response_201 = AgentRecord.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[AgentRecord | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: CreateAgent,
+) -> Response[AgentRecord | HTTPValidationError]:
+    """Create Agent
+
+     Create an agent. ``reserved=True`` and the ``h/`` namespace require H-employee privileges.
+
+    Args:
+        body (CreateAgent): ``POST /api/v2/agents`` body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AgentRecord | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: CreateAgent,
+) -> AgentRecord | HTTPValidationError | None:
+    """Create Agent
+
+     Create an agent. ``reserved=True`` and the ``h/`` namespace require H-employee privileges.
+
+    Args:
+        body (CreateAgent): ``POST /api/v2/agents`` body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AgentRecord | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: CreateAgent,
+) -> Response[AgentRecord | HTTPValidationError]:
+    """Create Agent
+
+     Create an agent. ``reserved=True`` and the ``h/`` namespace require H-employee privileges.
+
+    Args:
+        body (CreateAgent): ``POST /api/v2/agents`` body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AgentRecord | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: CreateAgent,
+) -> AgentRecord | HTTPValidationError | None:
+    """Create Agent
+
+     Create an agent. ``reserved=True`` and the ``h/`` namespace require H-employee privileges.
+
+    Args:
+        body (CreateAgent): ``POST /api/v2/agents`` body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AgentRecord | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/agents/delete_agent.py
+++ b/packages/sdk/src/agent_platform/api/agents/delete_agent.py
@@ -1,0 +1,167 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    agent_identifier: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/api/v2/agents/{agent_identifier}".format(
+            agent_identifier=quote(str(agent_identifier), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    agent_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Agent
+
+     Delete by identifier. Reserved rows: H employee only.
+
+    Args:
+        agent_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_identifier=agent_identifier,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    agent_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Delete Agent
+
+     Delete by identifier. Reserved rows: H employee only.
+
+    Args:
+        agent_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        agent_identifier=agent_identifier,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    agent_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Agent
+
+     Delete by identifier. Reserved rows: H employee only.
+
+    Args:
+        agent_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_identifier=agent_identifier,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    agent_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Delete Agent
+
+     Delete by identifier. Reserved rows: H employee only.
+
+    Args:
+        agent_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            agent_identifier=agent_identifier,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/agents/get_agent.py
+++ b/packages/sdk/src/agent_platform/api/agents/get_agent.py
@@ -1,0 +1,169 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.agent_record import AgentRecord
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    agent_identifier: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/agents/{agent_identifier}".format(
+            agent_identifier=quote(str(agent_identifier), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> AgentRecord | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = AgentRecord.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[AgentRecord | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    agent_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[AgentRecord | HTTPValidationError]:
+    """Get Agent
+
+     Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.
+
+    Args:
+        agent_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AgentRecord | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_identifier=agent_identifier,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    agent_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> AgentRecord | HTTPValidationError | None:
+    """Get Agent
+
+     Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.
+
+    Args:
+        agent_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AgentRecord | HTTPValidationError
+    """
+
+    return sync_detailed(
+        agent_identifier=agent_identifier,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    agent_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[AgentRecord | HTTPValidationError]:
+    """Get Agent
+
+     Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.
+
+    Args:
+        agent_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AgentRecord | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_identifier=agent_identifier,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    agent_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> AgentRecord | HTTPValidationError | None:
+    """Get Agent
+
+     Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.
+
+    Args:
+        agent_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AgentRecord | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            agent_identifier=agent_identifier,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/agents/list_agents.py
+++ b/packages/sdk/src/agent_platform/api/agents/list_agents.py
@@ -1,0 +1,217 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_agents_sort_type_0_item import ListAgentsSortType0Item
+from ...models.page_agent_record import PageAgentRecord
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListAgentsSortType0Item] | None | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["page"] = page
+
+    params["size"] = size
+
+    json_sort: list[str] | None | Unset
+    if isinstance(sort, Unset):
+        json_sort = UNSET
+    elif isinstance(sort, list):
+        json_sort = []
+        for sort_type_0_item_data in sort:
+            sort_type_0_item = sort_type_0_item_data.value
+            json_sort.append(sort_type_0_item)
+
+    else:
+        json_sort = sort
+    params["sort"] = json_sort
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/agents",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | PageAgentRecord | None:
+    if response.status_code == 200:
+        response_200 = PageAgentRecord.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | PageAgentRecord]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListAgentsSortType0Item] | None | Unset = UNSET,
+) -> Response[HTTPValidationError | PageAgentRecord]:
+    """List Agents
+
+     List reserved + caller's org agents.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListAgentsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PageAgentRecord]
+    """
+
+    kwargs = _get_kwargs(
+        page=page,
+        size=size,
+        sort=sort,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListAgentsSortType0Item] | None | Unset = UNSET,
+) -> HTTPValidationError | PageAgentRecord | None:
+    """List Agents
+
+     List reserved + caller's org agents.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListAgentsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PageAgentRecord
+    """
+
+    return sync_detailed(
+        client=client,
+        page=page,
+        size=size,
+        sort=sort,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListAgentsSortType0Item] | None | Unset = UNSET,
+) -> Response[HTTPValidationError | PageAgentRecord]:
+    """List Agents
+
+     List reserved + caller's org agents.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListAgentsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PageAgentRecord]
+    """
+
+    kwargs = _get_kwargs(
+        page=page,
+        size=size,
+        sort=sort,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListAgentsSortType0Item] | None | Unset = UNSET,
+) -> HTTPValidationError | PageAgentRecord | None:
+    """List Agents
+
+     List reserved + caller's org agents.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListAgentsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PageAgentRecord
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            page=page,
+            size=size,
+            sort=sort,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/agents/update_agent.py
+++ b/packages/sdk/src/agent_platform/api/agents/update_agent.py
@@ -1,0 +1,194 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.agent_record import AgentRecord
+from ...models.http_validation_error import HTTPValidationError
+from ...models.update_agent import UpdateAgent
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    agent_identifier: str,
+    *,
+    body: UpdateAgent,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/api/v2/agents/{agent_identifier}".format(
+            agent_identifier=quote(str(agent_identifier), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> AgentRecord | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = AgentRecord.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[AgentRecord | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    agent_identifier: str,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateAgent,
+) -> Response[AgentRecord | HTTPValidationError]:
+    """Update Agent
+
+     Replace ``spec``. ``spec.name`` must match the URL identifier; renames are not supported.
+
+    Args:
+        agent_identifier (str):
+        body (UpdateAgent): ``PUT /api/v2/agents/{agent_identifier}`` body. Full replace;
+            ``spec.name`` is immutable.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AgentRecord | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_identifier=agent_identifier,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    agent_identifier: str,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateAgent,
+) -> AgentRecord | HTTPValidationError | None:
+    """Update Agent
+
+     Replace ``spec``. ``spec.name`` must match the URL identifier; renames are not supported.
+
+    Args:
+        agent_identifier (str):
+        body (UpdateAgent): ``PUT /api/v2/agents/{agent_identifier}`` body. Full replace;
+            ``spec.name`` is immutable.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AgentRecord | HTTPValidationError
+    """
+
+    return sync_detailed(
+        agent_identifier=agent_identifier,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    agent_identifier: str,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateAgent,
+) -> Response[AgentRecord | HTTPValidationError]:
+    """Update Agent
+
+     Replace ``spec``. ``spec.name`` must match the URL identifier; renames are not supported.
+
+    Args:
+        agent_identifier (str):
+        body (UpdateAgent): ``PUT /api/v2/agents/{agent_identifier}`` body. Full replace;
+            ``spec.name`` is immutable.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AgentRecord | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_identifier=agent_identifier,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    agent_identifier: str,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateAgent,
+) -> AgentRecord | HTTPValidationError | None:
+    """Update Agent
+
+     Replace ``spec``. ``spec.name`` must match the URL identifier; renames are not supported.
+
+    Args:
+        agent_identifier (str):
+        body (UpdateAgent): ``PUT /api/v2/agents/{agent_identifier}`` body. Full replace;
+            ``spec.name`` is immutable.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AgentRecord | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            agent_identifier=agent_identifier,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/environments/__init__.py
+++ b/packages/sdk/src/agent_platform/api/environments/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/packages/sdk/src/agent_platform/api/environments/create_environment.py
+++ b/packages/sdk/src/agent_platform/api/environments/create_environment.py
@@ -1,0 +1,175 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_environment import CreateEnvironment
+from ...models.environment_record import EnvironmentRecord
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    *,
+    body: CreateEnvironment,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v2/environments",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> EnvironmentRecord | HTTPValidationError | None:
+    if response.status_code == 201:
+        response_201 = EnvironmentRecord.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[EnvironmentRecord | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: CreateEnvironment,
+) -> Response[EnvironmentRecord | HTTPValidationError]:
+    """Create Environment
+
+     Create an environment. ``reserved=True`` and the ``h/`` namespace require H-employee privileges.
+
+    Args:
+        body (CreateEnvironment): ``POST /api/v2/environments`` body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[EnvironmentRecord | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: CreateEnvironment,
+) -> EnvironmentRecord | HTTPValidationError | None:
+    """Create Environment
+
+     Create an environment. ``reserved=True`` and the ``h/`` namespace require H-employee privileges.
+
+    Args:
+        body (CreateEnvironment): ``POST /api/v2/environments`` body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        EnvironmentRecord | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: CreateEnvironment,
+) -> Response[EnvironmentRecord | HTTPValidationError]:
+    """Create Environment
+
+     Create an environment. ``reserved=True`` and the ``h/`` namespace require H-employee privileges.
+
+    Args:
+        body (CreateEnvironment): ``POST /api/v2/environments`` body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[EnvironmentRecord | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: CreateEnvironment,
+) -> EnvironmentRecord | HTTPValidationError | None:
+    """Create Environment
+
+     Create an environment. ``reserved=True`` and the ``h/`` namespace require H-employee privileges.
+
+    Args:
+        body (CreateEnvironment): ``POST /api/v2/environments`` body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        EnvironmentRecord | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/environments/delete_environment.py
+++ b/packages/sdk/src/agent_platform/api/environments/delete_environment.py
@@ -1,0 +1,167 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    env_identifier: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/api/v2/environments/{env_identifier}".format(
+            env_identifier=quote(str(env_identifier), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    env_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Environment
+
+     Delete by identifier. Reserved rows: H employee only.
+
+    Args:
+        env_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        env_identifier=env_identifier,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    env_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Delete Environment
+
+     Delete by identifier. Reserved rows: H employee only.
+
+    Args:
+        env_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        env_identifier=env_identifier,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    env_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Environment
+
+     Delete by identifier. Reserved rows: H employee only.
+
+    Args:
+        env_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        env_identifier=env_identifier,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    env_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Delete Environment
+
+     Delete by identifier. Reserved rows: H employee only.
+
+    Args:
+        env_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            env_identifier=env_identifier,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/environments/get_environment.py
+++ b/packages/sdk/src/agent_platform/api/environments/get_environment.py
@@ -1,0 +1,169 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.environment_record import EnvironmentRecord
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    env_identifier: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/environments/{env_identifier}".format(
+            env_identifier=quote(str(env_identifier), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> EnvironmentRecord | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = EnvironmentRecord.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[EnvironmentRecord | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    env_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[EnvironmentRecord | HTTPValidationError]:
+    """Get Environment
+
+     Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.
+
+    Args:
+        env_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[EnvironmentRecord | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        env_identifier=env_identifier,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    env_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> EnvironmentRecord | HTTPValidationError | None:
+    """Get Environment
+
+     Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.
+
+    Args:
+        env_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        EnvironmentRecord | HTTPValidationError
+    """
+
+    return sync_detailed(
+        env_identifier=env_identifier,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    env_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[EnvironmentRecord | HTTPValidationError]:
+    """Get Environment
+
+     Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.
+
+    Args:
+        env_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[EnvironmentRecord | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        env_identifier=env_identifier,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    env_identifier: str,
+    *,
+    client: AuthenticatedClient,
+) -> EnvironmentRecord | HTTPValidationError | None:
+    """Get Environment
+
+     Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.
+
+    Args:
+        env_identifier (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        EnvironmentRecord | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            env_identifier=env_identifier,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/environments/list_environments.py
+++ b/packages/sdk/src/agent_platform/api/environments/list_environments.py
@@ -1,0 +1,217 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_environments_sort_type_0_item import ListEnvironmentsSortType0Item
+from ...models.page_environment_record import PageEnvironmentRecord
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListEnvironmentsSortType0Item] | None | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["page"] = page
+
+    params["size"] = size
+
+    json_sort: list[str] | None | Unset
+    if isinstance(sort, Unset):
+        json_sort = UNSET
+    elif isinstance(sort, list):
+        json_sort = []
+        for sort_type_0_item_data in sort:
+            sort_type_0_item = sort_type_0_item_data.value
+            json_sort.append(sort_type_0_item)
+
+    else:
+        json_sort = sort
+    params["sort"] = json_sort
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/environments",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | PageEnvironmentRecord | None:
+    if response.status_code == 200:
+        response_200 = PageEnvironmentRecord.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | PageEnvironmentRecord]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListEnvironmentsSortType0Item] | None | Unset = UNSET,
+) -> Response[HTTPValidationError | PageEnvironmentRecord]:
+    """List Environments
+
+     List reserved + caller's org environments.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListEnvironmentsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PageEnvironmentRecord]
+    """
+
+    kwargs = _get_kwargs(
+        page=page,
+        size=size,
+        sort=sort,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListEnvironmentsSortType0Item] | None | Unset = UNSET,
+) -> HTTPValidationError | PageEnvironmentRecord | None:
+    """List Environments
+
+     List reserved + caller's org environments.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListEnvironmentsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PageEnvironmentRecord
+    """
+
+    return sync_detailed(
+        client=client,
+        page=page,
+        size=size,
+        sort=sort,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListEnvironmentsSortType0Item] | None | Unset = UNSET,
+) -> Response[HTTPValidationError | PageEnvironmentRecord]:
+    """List Environments
+
+     List reserved + caller's org environments.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListEnvironmentsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PageEnvironmentRecord]
+    """
+
+    kwargs = _get_kwargs(
+        page=page,
+        size=size,
+        sort=sort,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListEnvironmentsSortType0Item] | None | Unset = UNSET,
+) -> HTTPValidationError | PageEnvironmentRecord | None:
+    """List Environments
+
+     List reserved + caller's org environments.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListEnvironmentsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PageEnvironmentRecord
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            page=page,
+            size=size,
+            sort=sort,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/environments/update_environment.py
+++ b/packages/sdk/src/agent_platform/api/environments/update_environment.py
@@ -1,0 +1,198 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.environment_record import EnvironmentRecord
+from ...models.http_validation_error import HTTPValidationError
+from ...models.update_environment import UpdateEnvironment
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    env_identifier: str,
+    *,
+    body: UpdateEnvironment,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/api/v2/environments/{env_identifier}".format(
+            env_identifier=quote(str(env_identifier), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> EnvironmentRecord | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = EnvironmentRecord.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[EnvironmentRecord | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    env_identifier: str,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateEnvironment,
+) -> Response[EnvironmentRecord | HTTPValidationError]:
+    """Update Environment
+
+     Replace ``spec`` + ``description``. ``spec.id`` must match the URL identifier; renames are not
+    supported.
+
+    Args:
+        env_identifier (str):
+        body (UpdateEnvironment): ``PUT /api/v2/environments/{env_identifier}`` body. Full
+            replace; ``spec.id`` is immutable.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[EnvironmentRecord | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        env_identifier=env_identifier,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    env_identifier: str,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateEnvironment,
+) -> EnvironmentRecord | HTTPValidationError | None:
+    """Update Environment
+
+     Replace ``spec`` + ``description``. ``spec.id`` must match the URL identifier; renames are not
+    supported.
+
+    Args:
+        env_identifier (str):
+        body (UpdateEnvironment): ``PUT /api/v2/environments/{env_identifier}`` body. Full
+            replace; ``spec.id`` is immutable.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        EnvironmentRecord | HTTPValidationError
+    """
+
+    return sync_detailed(
+        env_identifier=env_identifier,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    env_identifier: str,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateEnvironment,
+) -> Response[EnvironmentRecord | HTTPValidationError]:
+    """Update Environment
+
+     Replace ``spec`` + ``description``. ``spec.id`` must match the URL identifier; renames are not
+    supported.
+
+    Args:
+        env_identifier (str):
+        body (UpdateEnvironment): ``PUT /api/v2/environments/{env_identifier}`` body. Full
+            replace; ``spec.id`` is immutable.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[EnvironmentRecord | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        env_identifier=env_identifier,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    env_identifier: str,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateEnvironment,
+) -> EnvironmentRecord | HTTPValidationError | None:
+    """Update Environment
+
+     Replace ``spec`` + ``description``. ``spec.id`` must match the URL identifier; renames are not
+    supported.
+
+    Args:
+        env_identifier (str):
+        body (UpdateEnvironment): ``PUT /api/v2/environments/{env_identifier}`` body. Full
+            replace; ``spec.id`` is immutable.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        EnvironmentRecord | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            env_identifier=env_identifier,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/memories/__init__.py
+++ b/packages/sdk/src/agent_platform/api/memories/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/packages/sdk/src/agent_platform/api/memories/create_memory.py
+++ b/packages/sdk/src/agent_platform/api/memories/create_memory.py
@@ -1,0 +1,179 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_memory import CreateMemory
+from ...models.http_validation_error import HTTPValidationError
+from ...models.memory_record import MemoryRecord
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    *,
+    body: CreateMemory,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v2/memories",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | MemoryRecord | None:
+    if response.status_code == 200:
+        response_200 = MemoryRecord.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 201:
+        response_201 = cast(Any, None)
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError | MemoryRecord]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: CreateMemory,
+) -> Response[Any | HTTPValidationError | MemoryRecord]:
+    """Create Memory
+
+     Upsert a memory by ``(org_id, namespace, key)``. 201 on create, 200 on update.
+
+    Args:
+        body (CreateMemory): Upsert a memory by ``(org_id, namespace, key)``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError | MemoryRecord]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: CreateMemory,
+) -> Any | HTTPValidationError | MemoryRecord | None:
+    """Create Memory
+
+     Upsert a memory by ``(org_id, namespace, key)``. 201 on create, 200 on update.
+
+    Args:
+        body (CreateMemory): Upsert a memory by ``(org_id, namespace, key)``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError | MemoryRecord
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: CreateMemory,
+) -> Response[Any | HTTPValidationError | MemoryRecord]:
+    """Create Memory
+
+     Upsert a memory by ``(org_id, namespace, key)``. 201 on create, 200 on update.
+
+    Args:
+        body (CreateMemory): Upsert a memory by ``(org_id, namespace, key)``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError | MemoryRecord]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: CreateMemory,
+) -> Any | HTTPValidationError | MemoryRecord | None:
+    """Create Memory
+
+     Upsert a memory by ``(org_id, namespace, key)``. 201 on create, 200 on update.
+
+    Args:
+        body (CreateMemory): Upsert a memory by ``(org_id, namespace, key)``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError | MemoryRecord
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/memories/delete_memory.py
+++ b/packages/sdk/src/agent_platform/api/memories/delete_memory.py
@@ -1,0 +1,168 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/api/v2/memories/{id}".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Memory
+
+     Delete a memory.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Delete Memory
+
+     Delete a memory.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Memory
+
+     Delete a memory.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Delete Memory
+
+     Delete a memory.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/memories/get_memory.py
+++ b/packages/sdk/src/agent_platform/api/memories/get_memory.py
@@ -1,0 +1,170 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.memory_record import MemoryRecord
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/memories/{id}".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MemoryRecord | None:
+    if response.status_code == 200:
+        response_200 = MemoryRecord.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MemoryRecord]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | MemoryRecord]:
+    """Get Memory
+
+     Get a memory by id.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryRecord]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | MemoryRecord | None:
+    """Get Memory
+
+     Get a memory by id.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryRecord
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | MemoryRecord]:
+    """Get Memory
+
+     Get a memory by id.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryRecord]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | MemoryRecord | None:
+    """Get Memory
+
+     Get a memory by id.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryRecord
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/memories/list_memories.py
+++ b/packages/sdk/src/agent_platform/api/memories/list_memories.py
@@ -1,0 +1,257 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_memories_sort_type_0_item import ListMemoriesSortType0Item
+from ...models.page_memory_record import PageMemoryRecord
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    namespace: None | str | Unset = UNSET,
+    key: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListMemoriesSortType0Item] | None | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    json_namespace: None | str | Unset
+    if isinstance(namespace, Unset):
+        json_namespace = UNSET
+    else:
+        json_namespace = namespace
+    params["namespace"] = json_namespace
+
+    json_key: None | str | Unset
+    if isinstance(key, Unset):
+        json_key = UNSET
+    else:
+        json_key = key
+    params["key"] = json_key
+
+    params["page"] = page
+
+    params["size"] = size
+
+    json_sort: list[str] | None | Unset
+    if isinstance(sort, Unset):
+        json_sort = UNSET
+    elif isinstance(sort, list):
+        json_sort = []
+        for sort_type_0_item_data in sort:
+            sort_type_0_item = sort_type_0_item_data.value
+            json_sort.append(sort_type_0_item)
+
+    else:
+        json_sort = sort
+    params["sort"] = json_sort
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/memories",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | PageMemoryRecord | None:
+    if response.status_code == 200:
+        response_200 = PageMemoryRecord.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | PageMemoryRecord]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    namespace: None | str | Unset = UNSET,
+    key: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListMemoriesSortType0Item] | None | Unset = UNSET,
+) -> Response[HTTPValidationError | PageMemoryRecord]:
+    """List Memories
+
+     List org memories; optional exact-namespace and key-prefix filters.
+
+    Args:
+        namespace (None | str | Unset): Exact namespace filter.
+        key (None | str | Unset): Key prefix filter.
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListMemoriesSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PageMemoryRecord]
+    """
+
+    kwargs = _get_kwargs(
+        namespace=namespace,
+        key=key,
+        page=page,
+        size=size,
+        sort=sort,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    namespace: None | str | Unset = UNSET,
+    key: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListMemoriesSortType0Item] | None | Unset = UNSET,
+) -> HTTPValidationError | PageMemoryRecord | None:
+    """List Memories
+
+     List org memories; optional exact-namespace and key-prefix filters.
+
+    Args:
+        namespace (None | str | Unset): Exact namespace filter.
+        key (None | str | Unset): Key prefix filter.
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListMemoriesSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PageMemoryRecord
+    """
+
+    return sync_detailed(
+        client=client,
+        namespace=namespace,
+        key=key,
+        page=page,
+        size=size,
+        sort=sort,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    namespace: None | str | Unset = UNSET,
+    key: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListMemoriesSortType0Item] | None | Unset = UNSET,
+) -> Response[HTTPValidationError | PageMemoryRecord]:
+    """List Memories
+
+     List org memories; optional exact-namespace and key-prefix filters.
+
+    Args:
+        namespace (None | str | Unset): Exact namespace filter.
+        key (None | str | Unset): Key prefix filter.
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListMemoriesSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PageMemoryRecord]
+    """
+
+    kwargs = _get_kwargs(
+        namespace=namespace,
+        key=key,
+        page=page,
+        size=size,
+        sort=sort,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    namespace: None | str | Unset = UNSET,
+    key: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListMemoriesSortType0Item] | None | Unset = UNSET,
+) -> HTTPValidationError | PageMemoryRecord | None:
+    """List Memories
+
+     List org memories; optional exact-namespace and key-prefix filters.
+
+    Args:
+        namespace (None | str | Unset): Exact namespace filter.
+        key (None | str | Unset): Key prefix filter.
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListMemoriesSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PageMemoryRecord
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            namespace=namespace,
+            key=key,
+            page=page,
+            size=size,
+            sort=sort,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/memories/update_memory.py
+++ b/packages/sdk/src/agent_platform/api/memories/update_memory.py
@@ -1,0 +1,191 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.memory_record import MemoryRecord
+from ...models.update_memory import UpdateMemory
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+    *,
+    body: UpdateMemory,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/api/v2/memories/{id}".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MemoryRecord | None:
+    if response.status_code == 200:
+        response_200 = MemoryRecord.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MemoryRecord]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateMemory,
+) -> Response[HTTPValidationError | MemoryRecord]:
+    """Update Memory
+
+     Update a memory's value.
+
+    Args:
+        id (UUID):
+        body (UpdateMemory): Update a memory's value in place.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryRecord]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateMemory,
+) -> HTTPValidationError | MemoryRecord | None:
+    """Update Memory
+
+     Update a memory's value.
+
+    Args:
+        id (UUID):
+        body (UpdateMemory): Update a memory's value in place.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryRecord
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateMemory,
+) -> Response[HTTPValidationError | MemoryRecord]:
+    """Update Memory
+
+     Update a memory's value.
+
+    Args:
+        id (UUID):
+        body (UpdateMemory): Update a memory's value in place.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryRecord]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateMemory,
+) -> HTTPValidationError | MemoryRecord | None:
+    """Update Memory
+
+     Update a memory's value.
+
+    Args:
+        id (UUID):
+        body (UpdateMemory): Update a memory's value in place.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryRecord
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/__init__.py
+++ b/packages/sdk/src/agent_platform/api/sessions/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/packages/sdk/src/agent_platform/api/sessions/cancel_session.py
+++ b/packages/sdk/src/agent_platform/api/sessions/cancel_session.py
@@ -1,0 +1,168 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/api/v2/sessions/{id}".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Cancel Session
+
+     Cancel the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Cancel Session
+
+     Cancel the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Cancel Session
+
+     Cancel the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Cancel Session
+
+     Cancel the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/create_session.py
+++ b/packages/sdk/src/agent_platform/api/sessions/create_session.py
@@ -1,0 +1,202 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session import Session
+from ...models.session_request import SessionRequest
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: SessionRequest,
+    idempotency_key: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(idempotency_key, Unset):
+        headers["Idempotency-Key"] = idempotency_key
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v2/sessions",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Session | None:
+    if response.status_code == 201:
+        response_201 = Session.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Session]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: SessionRequest,
+    idempotency_key: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Create Session
+
+     Create an agentic session.
+
+    Pass ``Idempotency-Key`` for safe retries: identical requests within 24h
+    return the original session; reuse with a different body returns 422.
+
+    Args:
+        idempotency_key (None | str | Unset):
+        body (SessionRequest): ``POST /api/v2/sessions`` body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        idempotency_key=idempotency_key,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: SessionRequest,
+    idempotency_key: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Create Session
+
+     Create an agentic session.
+
+    Pass ``Idempotency-Key`` for safe retries: identical requests within 24h
+    return the original session; reuse with a different body returns 422.
+
+    Args:
+        idempotency_key (None | str | Unset):
+        body (SessionRequest): ``POST /api/v2/sessions`` body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        idempotency_key=idempotency_key,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: SessionRequest,
+    idempotency_key: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Create Session
+
+     Create an agentic session.
+
+    Pass ``Idempotency-Key`` for safe retries: identical requests within 24h
+    return the original session; reuse with a different body returns 422.
+
+    Args:
+        idempotency_key (None | str | Unset):
+        body (SessionRequest): ``POST /api/v2/sessions`` body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        idempotency_key=idempotency_key,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: SessionRequest,
+    idempotency_key: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Create Session
+
+     Create an agentic session.
+
+    Pass ``Idempotency-Key`` for safe retries: identical requests within 24h
+    return the original session; reuse with a different body returns 422.
+
+    Args:
+        idempotency_key (None | str | Unset):
+        body (SessionRequest): ``POST /api/v2/sessions`` body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            idempotency_key=idempotency_key,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/force_session_answer.py
+++ b/packages/sdk/src/agent_platform/api/sessions/force_session_answer.py
@@ -1,0 +1,168 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v2/sessions/{id}/force_answer".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 202:
+        response_202 = response.json()
+        return response_202
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Force Session Answer
+
+     Ask the agent to emit a final answer on its next step.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Force Session Answer
+
+     Ask the agent to emit a final answer on its next step.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Force Session Answer
+
+     Ask the agent to emit a final answer on its next step.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Force Session Answer
+
+     Ask the agent to emit a final answer on its next step.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/get_session.py
+++ b/packages/sdk/src/agent_platform/api/sessions/get_session.py
@@ -1,0 +1,170 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session import Session
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/sessions/{id}".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Session | None:
+    if response.status_code == 200:
+        response_200 = Session.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Session]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | Session]:
+    """Get Session
+
+     Get a session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | Session | None:
+    """Get Session
+
+     Get a session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | Session]:
+    """Get Session
+
+     Get a session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | Session | None:
+    """Get Session
+
+     Get a session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/get_session_changes.py
+++ b/packages/sdk/src/agent_platform/api/sessions/get_session_changes.py
@@ -1,0 +1,245 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.trajectory_changes import TrajectoryChanges
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    id: UUID,
+    *,
+    from_index: int | Unset = 0,
+    limit: int | None | Unset = UNSET,
+    include_events: bool | Unset = True,
+    wait_for_seconds: int | Unset = 0,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["from_index"] = from_index
+
+    json_limit: int | None | Unset
+    if isinstance(limit, Unset):
+        json_limit = UNSET
+    else:
+        json_limit = limit
+    params["limit"] = json_limit
+
+    params["include_events"] = include_events
+
+    params["wait_for_seconds"] = wait_for_seconds
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/sessions/{id}/changes".format(
+            id=quote(str(id), safe=""),
+        ),
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | TrajectoryChanges | None:
+    if response.status_code == 200:
+        response_200 = TrajectoryChanges.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError | TrajectoryChanges]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    from_index: int | Unset = 0,
+    limit: int | None | Unset = UNSET,
+    include_events: bool | Unset = True,
+    wait_for_seconds: int | Unset = 0,
+) -> Response[Any | HTTPValidationError | TrajectoryChanges]:
+    """Get Session Changes
+
+     Long-poll for new events since ``from_index``; 204 if none arrive within ``wait_for_seconds``.
+
+    Args:
+        id (UUID):
+        from_index (int | Unset):  Default: 0.
+        limit (int | None | Unset):
+        include_events (bool | Unset):  Default: True.
+        wait_for_seconds (int | Unset):  Default: 0.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError | TrajectoryChanges]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        from_index=from_index,
+        limit=limit,
+        include_events=include_events,
+        wait_for_seconds=wait_for_seconds,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    from_index: int | Unset = 0,
+    limit: int | None | Unset = UNSET,
+    include_events: bool | Unset = True,
+    wait_for_seconds: int | Unset = 0,
+) -> Any | HTTPValidationError | TrajectoryChanges | None:
+    """Get Session Changes
+
+     Long-poll for new events since ``from_index``; 204 if none arrive within ``wait_for_seconds``.
+
+    Args:
+        id (UUID):
+        from_index (int | Unset):  Default: 0.
+        limit (int | None | Unset):
+        include_events (bool | Unset):  Default: True.
+        wait_for_seconds (int | Unset):  Default: 0.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError | TrajectoryChanges
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+        from_index=from_index,
+        limit=limit,
+        include_events=include_events,
+        wait_for_seconds=wait_for_seconds,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    from_index: int | Unset = 0,
+    limit: int | None | Unset = UNSET,
+    include_events: bool | Unset = True,
+    wait_for_seconds: int | Unset = 0,
+) -> Response[Any | HTTPValidationError | TrajectoryChanges]:
+    """Get Session Changes
+
+     Long-poll for new events since ``from_index``; 204 if none arrive within ``wait_for_seconds``.
+
+    Args:
+        id (UUID):
+        from_index (int | Unset):  Default: 0.
+        limit (int | None | Unset):
+        include_events (bool | Unset):  Default: True.
+        wait_for_seconds (int | Unset):  Default: 0.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError | TrajectoryChanges]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        from_index=from_index,
+        limit=limit,
+        include_events=include_events,
+        wait_for_seconds=wait_for_seconds,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    from_index: int | Unset = 0,
+    limit: int | None | Unset = UNSET,
+    include_events: bool | Unset = True,
+    wait_for_seconds: int | Unset = 0,
+) -> Any | HTTPValidationError | TrajectoryChanges | None:
+    """Get Session Changes
+
+     Long-poll for new events since ``from_index``; 204 if none arrive within ``wait_for_seconds``.
+
+    Args:
+        id (UUID):
+        from_index (int | Unset):  Default: 0.
+        limit (int | None | Unset):
+        include_events (bool | Unset):  Default: True.
+        wait_for_seconds (int | Unset):  Default: 0.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError | TrajectoryChanges
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+            from_index=from_index,
+            limit=limit,
+            include_events=include_events,
+            wait_for_seconds=wait_for_seconds,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/get_session_quota.py
+++ b/packages/sdk/src/agent_platform/api/sessions/get_session_quota.py
@@ -1,0 +1,143 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_status import QuotaStatus
+from ...types import UNSET, Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/sessions/quota",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | QuotaStatus | None:
+    if response.status_code == 200:
+        response_200 = QuotaStatus.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | QuotaStatus]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | QuotaStatus]:
+    """Get Session Quota
+
+     Concurrent-session quota for the authenticated user.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | QuotaStatus]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | QuotaStatus | None:
+    """Get Session Quota
+
+     Concurrent-session quota for the authenticated user.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | QuotaStatus
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | QuotaStatus]:
+    """Get Session Quota
+
+     Concurrent-session quota for the authenticated user.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | QuotaStatus]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | QuotaStatus | None:
+    """Get Session Quota
+
+     Concurrent-session quota for the authenticated user.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | QuotaStatus
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/get_session_resource.py
+++ b/packages/sdk/src/agent_platform/api/sessions/get_session_resource.py
@@ -1,0 +1,196 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+    bucket: str,
+    key: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/sessions/{id}/resources/{bucket}/{key}".format(
+            id=quote(str(id), safe=""),
+            bucket=quote(str(bucket), safe=""),
+            key=quote(str(key), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    bucket: str,
+    key: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Get Session Resource
+
+     Redirect to a presigned S3 URL for a session-owned resource.
+
+    Args:
+        id (UUID):
+        bucket (str):
+        key (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        bucket=bucket,
+        key=key,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    bucket: str,
+    key: str,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Get Session Resource
+
+     Redirect to a presigned S3 URL for a session-owned resource.
+
+    Args:
+        id (UUID):
+        bucket (str):
+        key (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        id=id,
+        bucket=bucket,
+        key=key,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    bucket: str,
+    key: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Get Session Resource
+
+     Redirect to a presigned S3 URL for a session-owned resource.
+
+    Args:
+        id (UUID):
+        bucket (str):
+        key (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        bucket=bucket,
+        key=key,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    bucket: str,
+    key: str,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Get Session Resource
+
+     Redirect to a presigned S3 URL for a session-owned resource.
+
+    Args:
+        id (UUID):
+        bucket (str):
+        key (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            bucket=bucket,
+            key=key,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/get_session_status.py
+++ b/packages/sdk/src/agent_platform/api/sessions/get_session_status.py
@@ -1,0 +1,170 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session_status import SessionStatus
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/sessions/{id}/status".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | SessionStatus | None:
+    if response.status_code == 200:
+        response_200 = SessionStatus.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | SessionStatus]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | SessionStatus]:
+    """Get Session Status
+
+     Get a session's live status.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SessionStatus]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | SessionStatus | None:
+    """Get Session Status
+
+     Get a session's live status.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SessionStatus
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | SessionStatus]:
+    """Get Session Status
+
+     Get a session's live status.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SessionStatus]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | SessionStatus | None:
+    """Get Session Status
+
+     Get a session's live status.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SessionStatus
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/list_session_events.py
+++ b/packages/sdk/src/agent_platform/api/sessions/list_session_events.py
@@ -1,0 +1,253 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_session_events_sort_type_0_item import ListSessionEventsSortType0Item
+from ...models.page_trajectory_event import PageTrajectoryEvent
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    id: UUID,
+    *,
+    page: int | Unset = 1,
+    size: int | Unset = 50,
+    sort: list[ListSessionEventsSortType0Item] | None | Unset = UNSET,
+    type_: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["page"] = page
+
+    params["size"] = size
+
+    json_sort: list[str] | None | Unset
+    if isinstance(sort, Unset):
+        json_sort = UNSET
+    elif isinstance(sort, list):
+        json_sort = []
+        for sort_type_0_item_data in sort:
+            sort_type_0_item = sort_type_0_item_data.value
+            json_sort.append(sort_type_0_item)
+
+    else:
+        json_sort = sort
+    params["sort"] = json_sort
+
+    json_type_: None | str | Unset
+    if isinstance(type_, Unset):
+        json_type_ = UNSET
+    else:
+        json_type_ = type_
+    params["type"] = json_type_
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/sessions/{id}/events".format(
+            id=quote(str(id), safe=""),
+        ),
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | PageTrajectoryEvent | None:
+    if response.status_code == 200:
+        response_200 = PageTrajectoryEvent.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | PageTrajectoryEvent]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    page: int | Unset = 1,
+    size: int | Unset = 50,
+    sort: list[ListSessionEventsSortType0Item] | None | Unset = UNSET,
+    type_: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | PageTrajectoryEvent]:
+    """List Session Events
+
+     Paginated event history. Use ``/changes`` for live tailing.
+
+    Args:
+        id (UUID):
+        page (int | Unset):  Default: 1.
+        size (int | Unset):  Default: 50.
+        sort (list[ListSessionEventsSortType0Item] | None | Unset):
+        type_ (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PageTrajectoryEvent]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        page=page,
+        size=size,
+        sort=sort,
+        type_=type_,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    page: int | Unset = 1,
+    size: int | Unset = 50,
+    sort: list[ListSessionEventsSortType0Item] | None | Unset = UNSET,
+    type_: None | str | Unset = UNSET,
+) -> HTTPValidationError | PageTrajectoryEvent | None:
+    """List Session Events
+
+     Paginated event history. Use ``/changes`` for live tailing.
+
+    Args:
+        id (UUID):
+        page (int | Unset):  Default: 1.
+        size (int | Unset):  Default: 50.
+        sort (list[ListSessionEventsSortType0Item] | None | Unset):
+        type_ (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PageTrajectoryEvent
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+        page=page,
+        size=size,
+        sort=sort,
+        type_=type_,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    page: int | Unset = 1,
+    size: int | Unset = 50,
+    sort: list[ListSessionEventsSortType0Item] | None | Unset = UNSET,
+    type_: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | PageTrajectoryEvent]:
+    """List Session Events
+
+     Paginated event history. Use ``/changes`` for live tailing.
+
+    Args:
+        id (UUID):
+        page (int | Unset):  Default: 1.
+        size (int | Unset):  Default: 50.
+        sort (list[ListSessionEventsSortType0Item] | None | Unset):
+        type_ (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PageTrajectoryEvent]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        page=page,
+        size=size,
+        sort=sort,
+        type_=type_,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    page: int | Unset = 1,
+    size: int | Unset = 50,
+    sort: list[ListSessionEventsSortType0Item] | None | Unset = UNSET,
+    type_: None | str | Unset = UNSET,
+) -> HTTPValidationError | PageTrajectoryEvent | None:
+    """List Session Events
+
+     Paginated event history. Use ``/changes`` for live tailing.
+
+    Args:
+        id (UUID):
+        page (int | Unset):  Default: 1.
+        size (int | Unset):  Default: 50.
+        sort (list[ListSessionEventsSortType0Item] | None | Unset):
+        type_ (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PageTrajectoryEvent
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+            page=page,
+            size=size,
+            sort=sort,
+            type_=type_,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/list_sessions.py
+++ b/packages/sdk/src/agent_platform/api/sessions/list_sessions.py
@@ -1,0 +1,327 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_sessions_owner import ListSessionsOwner
+from ...models.list_sessions_sort_type_0_item import ListSessionsSortType0Item
+from ...models.page_session_summary import PageSessionSummary
+from ...models.trajectory_status import TrajectoryStatus
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    owner: ListSessionsOwner | Unset = ListSessionsOwner.ME_IN_ORGANIZATION,
+    status: list[TrajectoryStatus] | None | Unset = UNSET,
+    agent: list[str] | None | Unset = UNSET,
+    group_id: None | str | Unset = UNSET,
+    parent_session_id: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListSessionsSortType0Item] | None | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    json_owner: str | Unset = UNSET
+    if not isinstance(owner, Unset):
+        json_owner = owner.value
+
+    params["owner"] = json_owner
+
+    json_status: list[str] | None | Unset
+    if isinstance(status, Unset):
+        json_status = UNSET
+    elif isinstance(status, list):
+        json_status = []
+        for status_type_0_item_data in status:
+            status_type_0_item = status_type_0_item_data.value
+            json_status.append(status_type_0_item)
+
+    else:
+        json_status = status
+    params["status"] = json_status
+
+    json_agent: list[str] | None | Unset
+    if isinstance(agent, Unset):
+        json_agent = UNSET
+    elif isinstance(agent, list):
+        json_agent = agent
+
+    else:
+        json_agent = agent
+    params["agent"] = json_agent
+
+    json_group_id: None | str | Unset
+    if isinstance(group_id, Unset):
+        json_group_id = UNSET
+    else:
+        json_group_id = group_id
+    params["group_id"] = json_group_id
+
+    json_parent_session_id: None | str | Unset
+    if isinstance(parent_session_id, Unset):
+        json_parent_session_id = UNSET
+    else:
+        json_parent_session_id = parent_session_id
+    params["parent_session_id"] = json_parent_session_id
+
+    params["page"] = page
+
+    params["size"] = size
+
+    json_sort: list[str] | None | Unset
+    if isinstance(sort, Unset):
+        json_sort = UNSET
+    elif isinstance(sort, list):
+        json_sort = []
+        for sort_type_0_item_data in sort:
+            sort_type_0_item = sort_type_0_item_data.value
+            json_sort.append(sort_type_0_item)
+
+    else:
+        json_sort = sort
+    params["sort"] = json_sort
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/sessions",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | PageSessionSummary | None:
+    if response.status_code == 200:
+        response_200 = PageSessionSummary.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | PageSessionSummary]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    owner: ListSessionsOwner | Unset = ListSessionsOwner.ME_IN_ORGANIZATION,
+    status: list[TrajectoryStatus] | None | Unset = UNSET,
+    agent: list[str] | None | Unset = UNSET,
+    group_id: None | str | Unset = UNSET,
+    parent_session_id: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListSessionsSortType0Item] | None | Unset = UNSET,
+) -> Response[HTTPValidationError | PageSessionSummary]:
+    """List Sessions
+
+     List sessions visible to ``user``.
+
+    Args:
+        owner (ListSessionsOwner | Unset):  Default: ListSessionsOwner.ME_IN_ORGANIZATION.
+        status (list[TrajectoryStatus] | None | Unset):
+        agent (list[str] | None | Unset):
+        group_id (None | str | Unset):
+        parent_session_id (None | str | Unset):
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListSessionsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PageSessionSummary]
+    """
+
+    kwargs = _get_kwargs(
+        owner=owner,
+        status=status,
+        agent=agent,
+        group_id=group_id,
+        parent_session_id=parent_session_id,
+        page=page,
+        size=size,
+        sort=sort,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    owner: ListSessionsOwner | Unset = ListSessionsOwner.ME_IN_ORGANIZATION,
+    status: list[TrajectoryStatus] | None | Unset = UNSET,
+    agent: list[str] | None | Unset = UNSET,
+    group_id: None | str | Unset = UNSET,
+    parent_session_id: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListSessionsSortType0Item] | None | Unset = UNSET,
+) -> HTTPValidationError | PageSessionSummary | None:
+    """List Sessions
+
+     List sessions visible to ``user``.
+
+    Args:
+        owner (ListSessionsOwner | Unset):  Default: ListSessionsOwner.ME_IN_ORGANIZATION.
+        status (list[TrajectoryStatus] | None | Unset):
+        agent (list[str] | None | Unset):
+        group_id (None | str | Unset):
+        parent_session_id (None | str | Unset):
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListSessionsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PageSessionSummary
+    """
+
+    return sync_detailed(
+        client=client,
+        owner=owner,
+        status=status,
+        agent=agent,
+        group_id=group_id,
+        parent_session_id=parent_session_id,
+        page=page,
+        size=size,
+        sort=sort,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    owner: ListSessionsOwner | Unset = ListSessionsOwner.ME_IN_ORGANIZATION,
+    status: list[TrajectoryStatus] | None | Unset = UNSET,
+    agent: list[str] | None | Unset = UNSET,
+    group_id: None | str | Unset = UNSET,
+    parent_session_id: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListSessionsSortType0Item] | None | Unset = UNSET,
+) -> Response[HTTPValidationError | PageSessionSummary]:
+    """List Sessions
+
+     List sessions visible to ``user``.
+
+    Args:
+        owner (ListSessionsOwner | Unset):  Default: ListSessionsOwner.ME_IN_ORGANIZATION.
+        status (list[TrajectoryStatus] | None | Unset):
+        agent (list[str] | None | Unset):
+        group_id (None | str | Unset):
+        parent_session_id (None | str | Unset):
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListSessionsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PageSessionSummary]
+    """
+
+    kwargs = _get_kwargs(
+        owner=owner,
+        status=status,
+        agent=agent,
+        group_id=group_id,
+        parent_session_id=parent_session_id,
+        page=page,
+        size=size,
+        sort=sort,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    owner: ListSessionsOwner | Unset = ListSessionsOwner.ME_IN_ORGANIZATION,
+    status: list[TrajectoryStatus] | None | Unset = UNSET,
+    agent: list[str] | None | Unset = UNSET,
+    group_id: None | str | Unset = UNSET,
+    parent_session_id: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListSessionsSortType0Item] | None | Unset = UNSET,
+) -> HTTPValidationError | PageSessionSummary | None:
+    """List Sessions
+
+     List sessions visible to ``user``.
+
+    Args:
+        owner (ListSessionsOwner | Unset):  Default: ListSessionsOwner.ME_IN_ORGANIZATION.
+        status (list[TrajectoryStatus] | None | Unset):
+        agent (list[str] | None | Unset):
+        group_id (None | str | Unset):
+        parent_session_id (None | str | Unset):
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListSessionsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PageSessionSummary
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            owner=owner,
+            status=status,
+            agent=agent,
+            group_id=group_id,
+            parent_session_id=parent_session_id,
+            page=page,
+            size=size,
+            sort=sort,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/pause_session.py
+++ b/packages/sdk/src/agent_platform/api/sessions/pause_session.py
@@ -1,0 +1,168 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v2/sessions/{id}/pause".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 202:
+        response_202 = response.json()
+        return response_202
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Pause Session
+
+     Pause the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Pause Session
+
+     Pause the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Pause Session
+
+     Pause the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Pause Session
+
+     Pause the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/resume_session.py
+++ b/packages/sdk/src/agent_platform/api/sessions/resume_session.py
@@ -1,0 +1,168 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v2/sessions/{id}/resume".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 202:
+        response_202 = response.json()
+        return response_202
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Resume Session
+
+     Resume the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Resume Session
+
+     Resume the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Resume Session
+
+     Resume the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Resume Session
+
+     Resume the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/send_session_messages.py
+++ b/packages/sdk/src/agent_platform/api/sessions/send_session_messages.py
@@ -1,0 +1,193 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.user_message_batch import UserMessageBatch
+from ...models.user_message_event import UserMessageEvent
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+    *,
+    body: UserMessageBatch | UserMessageEvent,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v2/sessions/{id}/messages".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    if isinstance(body, UserMessageEvent):
+        _kwargs["json"] = body.to_dict()
+    else:
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 202:
+        response_202 = response.json()
+        return response_202
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: UserMessageBatch | UserMessageEvent,
+) -> Response[Any | HTTPValidationError]:
+    """Send Session Messages
+
+     Send a user message (single or batch).
+
+    Args:
+        id (UUID):
+        body (UserMessageBatch | UserMessageEvent):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: UserMessageBatch | UserMessageEvent,
+) -> Any | HTTPValidationError | None:
+    """Send Session Messages
+
+     Send a user message (single or batch).
+
+    Args:
+        id (UUID):
+        body (UserMessageBatch | UserMessageEvent):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: UserMessageBatch | UserMessageEvent,
+) -> Response[Any | HTTPValidationError]:
+    """Send Session Messages
+
+     Send a user message (single or batch).
+
+    Args:
+        id (UUID):
+        body (UserMessageBatch | UserMessageEvent):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: UserMessageBatch | UserMessageEvent,
+) -> Any | HTTPValidationError | None:
+    """Send Session Messages
+
+     Send a user message (single or batch).
+
+    Args:
+        id (UUID):
+        body (UserMessageBatch | UserMessageEvent):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/share_session.py
+++ b/packages/sdk/src/agent_platform/api/sessions/share_session.py
@@ -1,0 +1,170 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.share_link import ShareLink
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v2/sessions/{id}/share".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ShareLink | None:
+    if response.status_code == 200:
+        response_200 = ShareLink.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ShareLink]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | ShareLink]:
+    """Share Session
+
+     Make the session publicly readable; returns the share URL path.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ShareLink]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | ShareLink | None:
+    """Share Session
+
+     Make the session publicly readable; returns the share URL path.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ShareLink
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | ShareLink]:
+    """Share Session
+
+     Make the session publicly readable; returns the share URL path.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ShareLink]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | ShareLink | None:
+    """Share Session
+
+     Make the session publicly readable; returns the share URL path.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ShareLink
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/submit_event_feedback.py
+++ b/packages/sdk/src/agent_platform/api/sessions/submit_event_feedback.py
@@ -1,0 +1,203 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.feedback import Feedback
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+    event_index: int,
+    *,
+    body: Feedback,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/api/v2/sessions/{id}/events/{event_index}/feedback".format(
+            id=quote(str(id), safe=""),
+            event_index=quote(str(event_index), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    event_index: int,
+    *,
+    client: AuthenticatedClient,
+    body: Feedback,
+) -> Response[Any | HTTPValidationError]:
+    """Submit Event Feedback
+
+     Record feedback on a single event in the session's history.
+
+    Args:
+        id (UUID):
+        event_index (int):
+        body (Feedback): Feedback on the semantic success of the trajectory.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        event_index=event_index,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    event_index: int,
+    *,
+    client: AuthenticatedClient,
+    body: Feedback,
+) -> Any | HTTPValidationError | None:
+    """Submit Event Feedback
+
+     Record feedback on a single event in the session's history.
+
+    Args:
+        id (UUID):
+        event_index (int):
+        body (Feedback): Feedback on the semantic success of the trajectory.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        id=id,
+        event_index=event_index,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    event_index: int,
+    *,
+    client: AuthenticatedClient,
+    body: Feedback,
+) -> Response[Any | HTTPValidationError]:
+    """Submit Event Feedback
+
+     Record feedback on a single event in the session's history.
+
+    Args:
+        id (UUID):
+        event_index (int):
+        body (Feedback): Feedback on the semantic success of the trajectory.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        event_index=event_index,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    event_index: int,
+    *,
+    client: AuthenticatedClient,
+    body: Feedback,
+) -> Any | HTTPValidationError | None:
+    """Submit Event Feedback
+
+     Record feedback on a single event in the session's history.
+
+    Args:
+        id (UUID):
+        event_index (int):
+        body (Feedback): Feedback on the semantic success of the trajectory.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            event_index=event_index,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/submit_session_feedback.py
+++ b/packages/sdk/src/agent_platform/api/sessions/submit_session_feedback.py
@@ -1,0 +1,189 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.feedback import Feedback
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+    *,
+    body: Feedback,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v2/sessions/{id}/feedback".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: Feedback,
+) -> Response[Any | HTTPValidationError]:
+    """Submit Session Feedback
+
+     Record semantic-success feedback on the whole session.
+
+    Args:
+        id (UUID):
+        body (Feedback): Feedback on the semantic success of the trajectory.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: Feedback,
+) -> Any | HTTPValidationError | None:
+    """Submit Session Feedback
+
+     Record semantic-success feedback on the whole session.
+
+    Args:
+        id (UUID):
+        body (Feedback): Feedback on the semantic success of the trajectory.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: Feedback,
+) -> Response[Any | HTTPValidationError]:
+    """Submit Session Feedback
+
+     Record semantic-success feedback on the whole session.
+
+    Args:
+        id (UUID):
+        body (Feedback): Feedback on the semantic success of the trajectory.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: Feedback,
+) -> Any | HTTPValidationError | None:
+    """Submit Session Feedback
+
+     Record semantic-success feedback on the whole session.
+
+    Args:
+        id (UUID):
+        body (Feedback): Feedback on the semantic success of the trajectory.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/sessions/unshare_session.py
+++ b/packages/sdk/src/agent_platform/api/sessions/unshare_session.py
@@ -1,0 +1,168 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/api/v2/sessions/{id}/share".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Unshare Session
+
+     Revoke public access to the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Unshare Session
+
+     Revoke public access to the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Unshare Session
+
+     Revoke public access to the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Unshare Session
+
+     Revoke public access to the session.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/skills/__init__.py
+++ b/packages/sdk/src/agent_platform/api/skills/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/packages/sdk/src/agent_platform/api/skills/create_skill.py
+++ b/packages/sdk/src/agent_platform/api/skills/create_skill.py
@@ -1,0 +1,175 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_skill import CreateSkill
+from ...models.http_validation_error import HTTPValidationError
+from ...models.skill_record import SkillRecord
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    *,
+    body: CreateSkill,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v2/skills",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | SkillRecord | None:
+    if response.status_code == 201:
+        response_201 = SkillRecord.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | SkillRecord]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: CreateSkill,
+) -> Response[HTTPValidationError | SkillRecord]:
+    """Create Skill
+
+     Create a skill.
+
+    Args:
+        body (CreateSkill): Request to create a skill.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SkillRecord]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: CreateSkill,
+) -> HTTPValidationError | SkillRecord | None:
+    """Create Skill
+
+     Create a skill.
+
+    Args:
+        body (CreateSkill): Request to create a skill.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SkillRecord
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: CreateSkill,
+) -> Response[HTTPValidationError | SkillRecord]:
+    """Create Skill
+
+     Create a skill.
+
+    Args:
+        body (CreateSkill): Request to create a skill.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SkillRecord]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: CreateSkill,
+) -> HTTPValidationError | SkillRecord | None:
+    """Create Skill
+
+     Create a skill.
+
+    Args:
+        body (CreateSkill): Request to create a skill.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SkillRecord
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/skills/delete_skill.py
+++ b/packages/sdk/src/agent_platform/api/skills/delete_skill.py
@@ -1,0 +1,168 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/api/v2/skills/{id}".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Skill
+
+     Delete a skill.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Delete Skill
+
+     Delete a skill.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Skill
+
+     Delete a skill.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Delete Skill
+
+     Delete a skill.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/skills/get_skill.py
+++ b/packages/sdk/src/agent_platform/api/skills/get_skill.py
@@ -1,0 +1,170 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.skill_record import SkillRecord
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/skills/{id}".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | SkillRecord | None:
+    if response.status_code == 200:
+        response_200 = SkillRecord.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | SkillRecord]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | SkillRecord]:
+    """Get Skill
+
+     Get a skill by id.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SkillRecord]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | SkillRecord | None:
+    """Get Skill
+
+     Get a skill by id.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SkillRecord
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | SkillRecord]:
+    """Get Skill
+
+     Get a skill by id.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SkillRecord]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | SkillRecord | None:
+    """Get Skill
+
+     Get a skill by id.
+
+    Args:
+        id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SkillRecord
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/skills/list_skills.py
+++ b/packages/sdk/src/agent_platform/api/skills/list_skills.py
@@ -1,0 +1,237 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_skills_sort_type_0_item import ListSkillsSortType0Item
+from ...models.page_skill_record import PageSkillRecord
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    name: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListSkillsSortType0Item] | None | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    json_name: None | str | Unset
+    if isinstance(name, Unset):
+        json_name = UNSET
+    else:
+        json_name = name
+    params["name"] = json_name
+
+    params["page"] = page
+
+    params["size"] = size
+
+    json_sort: list[str] | None | Unset
+    if isinstance(sort, Unset):
+        json_sort = UNSET
+    elif isinstance(sort, list):
+        json_sort = []
+        for sort_type_0_item_data in sort:
+            sort_type_0_item = sort_type_0_item_data.value
+            json_sort.append(sort_type_0_item)
+
+    else:
+        json_sort = sort
+    params["sort"] = json_sort
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v2/skills",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | PageSkillRecord | None:
+    if response.status_code == 200:
+        response_200 = PageSkillRecord.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | PageSkillRecord]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    name: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListSkillsSortType0Item] | None | Unset = UNSET,
+) -> Response[HTTPValidationError | PageSkillRecord]:
+    """List Skills
+
+     List skills for the current org, optionally filtered by name prefix.
+
+    Args:
+        name (None | str | Unset): Filter by name prefix.
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListSkillsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PageSkillRecord]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+        page=page,
+        size=size,
+        sort=sort,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    name: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListSkillsSortType0Item] | None | Unset = UNSET,
+) -> HTTPValidationError | PageSkillRecord | None:
+    """List Skills
+
+     List skills for the current org, optionally filtered by name prefix.
+
+    Args:
+        name (None | str | Unset): Filter by name prefix.
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListSkillsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PageSkillRecord
+    """
+
+    return sync_detailed(
+        client=client,
+        name=name,
+        page=page,
+        size=size,
+        sort=sort,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    name: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListSkillsSortType0Item] | None | Unset = UNSET,
+) -> Response[HTTPValidationError | PageSkillRecord]:
+    """List Skills
+
+     List skills for the current org, optionally filtered by name prefix.
+
+    Args:
+        name (None | str | Unset): Filter by name prefix.
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListSkillsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PageSkillRecord]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+        page=page,
+        size=size,
+        sort=sort,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    name: None | str | Unset = UNSET,
+    page: int | Unset = 1,
+    size: int | Unset = 10,
+    sort: list[ListSkillsSortType0Item] | None | Unset = UNSET,
+) -> HTTPValidationError | PageSkillRecord | None:
+    """List Skills
+
+     List skills for the current org, optionally filtered by name prefix.
+
+    Args:
+        name (None | str | Unset): Filter by name prefix.
+        page (int | Unset): Page number (1-based) Default: 1.
+        size (int | Unset): Number of items per page Default: 10.
+        sort (list[ListSkillsSortType0Item] | None | Unset): Sort by field
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PageSkillRecord
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            name=name,
+            page=page,
+            size=size,
+            sort=sort,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/api/skills/update_skill.py
+++ b/packages/sdk/src/agent_platform/api/skills/update_skill.py
@@ -1,0 +1,191 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.skill_record import SkillRecord
+from ...models.update_skill import UpdateSkill
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    id: UUID,
+    *,
+    body: UpdateSkill,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/api/v2/skills/{id}".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | SkillRecord | None:
+    if response.status_code == 200:
+        response_200 = SkillRecord.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | SkillRecord]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateSkill,
+) -> Response[HTTPValidationError | SkillRecord]:
+    """Update Skill
+
+     Update a skill's content.
+
+    Args:
+        id (UUID):
+        body (UpdateSkill): Request to update a skill. Full replacement; `name` is immutable.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SkillRecord]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateSkill,
+) -> HTTPValidationError | SkillRecord | None:
+    """Update Skill
+
+     Update a skill's content.
+
+    Args:
+        id (UUID):
+        body (UpdateSkill): Request to update a skill. Full replacement; `name` is immutable.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SkillRecord
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateSkill,
+) -> Response[HTTPValidationError | SkillRecord]:
+    """Update Skill
+
+     Update a skill's content.
+
+    Args:
+        id (UUID):
+        body (UpdateSkill): Request to update a skill. Full replacement; `name` is immutable.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SkillRecord]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient,
+    body: UpdateSkill,
+) -> HTTPValidationError | SkillRecord | None:
+    """Update Skill
+
+     Update a skill's content.
+
+    Args:
+        id (UUID):
+        body (UpdateSkill): Request to update a skill. Full replacement; `name` is immutable.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SkillRecord
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/packages/sdk/src/agent_platform/client.py
+++ b/packages/sdk/src/agent_platform/client.py
@@ -1,0 +1,268 @@
+import ssl
+from typing import Any
+
+import httpx
+from attrs import define, evolve, field
+
+
+@define
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    def with_headers(self, headers: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "Client":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "Client":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "Client":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "Client":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+@define
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/packages/sdk/src/agent_platform/errors.py
+++ b/packages/sdk/src/agent_platform/errors.py
@@ -1,0 +1,16 @@
+"""Contains shared errors types that can be raised from API functions"""
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+
+__all__ = ["UnexpectedStatus"]

--- a/packages/sdk/src/agent_platform/models/__init__.py
+++ b/packages/sdk/src/agent_platform/models/__init__.py
@@ -1,0 +1,117 @@
+"""Contains all the data models used in inputs/outputs"""
+
+from .agent import Agent
+from .agent_record import AgentRecord
+from .browser import Browser
+from .code_sandbox import CodeSandbox
+from .code_sandbox_env import CodeSandboxEnv
+from .create_agent import CreateAgent
+from .create_environment import CreateEnvironment
+from .create_memory import CreateMemory
+from .create_skill import CreateSkill
+from .environment_record import EnvironmentRecord
+from .feedback import Feedback
+from .http_validation_error import HTTPValidationError
+from .list_agents_sort_type_0_item import ListAgentsSortType0Item
+from .list_environments_sort_type_0_item import ListEnvironmentsSortType0Item
+from .list_memories_sort_type_0_item import ListMemoriesSortType0Item
+from .list_session_events_sort_type_0_item import ListSessionEventsSortType0Item
+from .list_sessions_owner import ListSessionsOwner
+from .list_sessions_sort_type_0_item import ListSessionsSortType0Item
+from .list_skills_sort_type_0_item import ListSkillsSortType0Item
+from .mcp import MCP
+from .mcp_server import MCPServer
+from .mcp_server_env import MCPServerEnv
+from .mcp_server_headers import MCPServerHeaders
+from .mcp_server_transport import MCPServerTransport
+from .memory import Memory
+from .memory_record import MemoryRecord
+from .metrics import Metrics
+from .model_cost import ModelCost
+from .model_usage import ModelUsage
+from .page_agent_record import PageAgentRecord
+from .page_environment_record import PageEnvironmentRecord
+from .page_memory_record import PageMemoryRecord
+from .page_session_summary import PageSessionSummary
+from .page_skill_record import PageSkillRecord
+from .page_trajectory_event import PageTrajectoryEvent
+from .quota_status import QuotaStatus
+from .quota_status_scope import QuotaStatusScope
+from .session import Session
+from .session_request import SessionRequest
+from .session_status import SessionStatus
+from .session_summary import SessionSummary
+from .share_link import ShareLink
+from .skill import Skill
+from .skill_record import SkillRecord
+from .trajectory_changes import TrajectoryChanges
+from .trajectory_changes_answer_type_1 import TrajectoryChangesAnswerType1
+from .trajectory_event import TrajectoryEvent
+from .trajectory_status import TrajectoryStatus
+from .update_agent import UpdateAgent
+from .update_environment import UpdateEnvironment
+from .update_memory import UpdateMemory
+from .update_skill import UpdateSkill
+from .user_message_batch import UserMessageBatch
+from .user_message_event import UserMessageEvent
+from .validation_error import ValidationError
+from .validation_error_context import ValidationErrorContext
+
+__all__ = (
+    "Agent",
+    "AgentRecord",
+    "Browser",
+    "CodeSandbox",
+    "CodeSandboxEnv",
+    "CreateAgent",
+    "CreateEnvironment",
+    "CreateMemory",
+    "CreateSkill",
+    "EnvironmentRecord",
+    "Feedback",
+    "HTTPValidationError",
+    "ListAgentsSortType0Item",
+    "ListEnvironmentsSortType0Item",
+    "ListMemoriesSortType0Item",
+    "ListSessionEventsSortType0Item",
+    "ListSessionsOwner",
+    "ListSessionsSortType0Item",
+    "ListSkillsSortType0Item",
+    "MCP",
+    "MCPServer",
+    "MCPServerEnv",
+    "MCPServerHeaders",
+    "MCPServerTransport",
+    "Memory",
+    "MemoryRecord",
+    "Metrics",
+    "ModelCost",
+    "ModelUsage",
+    "PageAgentRecord",
+    "PageEnvironmentRecord",
+    "PageMemoryRecord",
+    "PageSessionSummary",
+    "PageSkillRecord",
+    "PageTrajectoryEvent",
+    "QuotaStatus",
+    "QuotaStatusScope",
+    "Session",
+    "SessionRequest",
+    "SessionStatus",
+    "SessionSummary",
+    "ShareLink",
+    "Skill",
+    "SkillRecord",
+    "TrajectoryChanges",
+    "TrajectoryChangesAnswerType1",
+    "TrajectoryEvent",
+    "TrajectoryStatus",
+    "UpdateAgent",
+    "UpdateEnvironment",
+    "UpdateMemory",
+    "UpdateSkill",
+    "UserMessageBatch",
+    "UserMessageEvent",
+    "ValidationError",
+    "ValidationErrorContext",
+)

--- a/packages/sdk/src/agent_platform/models/agent.py
+++ b/packages/sdk/src/agent_platform/models/agent.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.browser import Browser
+    from ..models.code_sandbox import CodeSandbox
+    from ..models.mcp import MCP
+    from ..models.memory import Memory
+    from ..models.skill import Skill
+
+
+T = TypeVar("T", bound="Agent")
+
+
+class Agent(BaseModel):
+    """Declarative agent definition.
+
+    Attributes:
+        name (str): Unique catalog identifier for this agent. Format: lowercase ASCII letters, digits and hyphens; must
+            start and end with alphanumeric; max 63 chars per segment; optional single 'org/' namespace prefix (e.g. 'h/web-
+            environment').
+        description (str): Short summary advertised to parent agents that may delegate to this one.
+        environments (list[Browser | CodeSandbox | MCP | Memory | str]): Environments the agent runs in. A string entry
+            references a catalog id; an inline Environment defines an ad-hoc environment. At least one entry, at most one
+            per kind.
+        model (None | str | Unset): Model id; defaults to the platform-provided one if omitted.
+        instructions (None | str | Unset): Steering text appended to the system prompt.
+        subagents (list[Agent | str] | None | Unset): Agents this one can spawn. A string entry references another
+            catalog id; an inline Agent defines an ad-hoc sub-agent.
+        skills (list[Skill | str] | None | Unset): Skills available to this agent. A string entry references a catalog
+            id; an inline Skill defines an ad-hoc skill.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    name: str
+    description: str
+    environments: list[Browser | CodeSandbox | MCP | Memory | str]
+    model: None | str | Unset = UNSET
+    instructions: None | str | Unset = UNSET
+    subagents: list[Agent | str] | None | Unset = UNSET
+    skills: list[Skill | str] | None | Unset = UNSET
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.browser import Browser
+        from ..models.code_sandbox import CodeSandbox
+        from ..models.mcp import MCP
+        from ..models.memory import Memory
+        from ..models.skill import Skill
+
+        name = self.name
+
+        description = self.description
+
+        environments = []
+        for environments_item_data in self.environments:
+            environments_item: dict[str, Any] | str
+            if isinstance(environments_item_data, Browser):
+                environments_item = environments_item_data.to_dict()
+            elif isinstance(environments_item_data, CodeSandbox):
+                environments_item = environments_item_data.to_dict()
+            elif isinstance(environments_item_data, MCP):
+                environments_item = environments_item_data.to_dict()
+            elif isinstance(environments_item_data, Memory):
+                environments_item = environments_item_data.to_dict()
+            else:
+                environments_item = environments_item_data
+            environments.append(environments_item)
+
+        model: None | str | Unset
+        if isinstance(self.model, Unset):
+            model = UNSET
+        else:
+            model = self.model
+
+        instructions: None | str | Unset
+        if isinstance(self.instructions, Unset):
+            instructions = UNSET
+        else:
+            instructions = self.instructions
+
+        subagents: list[dict[str, Any] | str] | None | Unset
+        if isinstance(self.subagents, Unset):
+            subagents = UNSET
+        elif isinstance(self.subagents, list):
+            subagents = []
+            for subagents_type_0_item_data in self.subagents:
+                subagents_type_0_item: dict[str, Any] | str
+                if isinstance(subagents_type_0_item_data, Agent):
+                    subagents_type_0_item = subagents_type_0_item_data.to_dict()
+                else:
+                    subagents_type_0_item = subagents_type_0_item_data
+                subagents.append(subagents_type_0_item)
+
+        else:
+            subagents = self.subagents
+
+        skills: list[dict[str, Any] | str] | None | Unset
+        if isinstance(self.skills, Unset):
+            skills = UNSET
+        elif isinstance(self.skills, list):
+            skills = []
+            for skills_type_0_item_data in self.skills:
+                skills_type_0_item: dict[str, Any] | str
+                if isinstance(skills_type_0_item_data, Skill):
+                    skills_type_0_item = skills_type_0_item_data.to_dict()
+                else:
+                    skills_type_0_item = skills_type_0_item_data
+                skills.append(skills_type_0_item)
+
+        else:
+            skills = self.skills
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+                "description": description,
+                "environments": environments,
+            }
+        )
+        if model is not UNSET:
+            field_dict["model"] = model
+        if instructions is not UNSET:
+            field_dict["instructions"] = instructions
+        if subagents is not UNSET:
+            field_dict["subagents"] = subagents
+        if skills is not UNSET:
+            field_dict["skills"] = skills
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.browser import Browser
+        from ..models.code_sandbox import CodeSandbox
+        from ..models.mcp import MCP
+        from ..models.memory import Memory
+        from ..models.skill import Skill
+
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        description = d.pop("description")
+
+        environments = []
+        _environments = d.pop("environments")
+        for environments_item_data in _environments:
+
+            def _parse_environments_item(data: object) -> Browser | CodeSandbox | MCP | Memory | str:
+                try:
+                    if not isinstance(data, dict):
+                        raise TypeError()
+                    environments_item_type_1_type_0 = Browser.from_dict(data)
+
+                    return environments_item_type_1_type_0
+                except (TypeError, ValueError, AttributeError, KeyError):
+                    pass
+                try:
+                    if not isinstance(data, dict):
+                        raise TypeError()
+                    environments_item_type_1_type_1 = CodeSandbox.from_dict(data)
+
+                    return environments_item_type_1_type_1
+                except (TypeError, ValueError, AttributeError, KeyError):
+                    pass
+                try:
+                    if not isinstance(data, dict):
+                        raise TypeError()
+                    environments_item_type_1_type_2 = MCP.from_dict(data)
+
+                    return environments_item_type_1_type_2
+                except (TypeError, ValueError, AttributeError, KeyError):
+                    pass
+                try:
+                    if not isinstance(data, dict):
+                        raise TypeError()
+                    environments_item_type_1_type_3 = Memory.from_dict(data)
+
+                    return environments_item_type_1_type_3
+                except (TypeError, ValueError, AttributeError, KeyError):
+                    pass
+                return cast(Browser | CodeSandbox | MCP | Memory | str, data)
+
+            environments_item = _parse_environments_item(environments_item_data)
+
+            environments.append(environments_item)
+
+        def _parse_model(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        model = _parse_model(d.pop("model", UNSET))
+
+        def _parse_instructions(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        instructions = _parse_instructions(d.pop("instructions", UNSET))
+
+        def _parse_subagents(data: object) -> list[Agent | str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                subagents_type_0 = []
+                _subagents_type_0 = data
+                for subagents_type_0_item_data in _subagents_type_0:
+
+                    def _parse_subagents_type_0_item(data: object) -> Agent | str:
+                        try:
+                            if not isinstance(data, dict):
+                                raise TypeError()
+                            subagents_type_0_item_type_1 = Agent.from_dict(data)
+
+                            return subagents_type_0_item_type_1
+                        except (TypeError, ValueError, AttributeError, KeyError):
+                            pass
+                        return cast(Agent | str, data)
+
+                    subagents_type_0_item = _parse_subagents_type_0_item(subagents_type_0_item_data)
+
+                    subagents_type_0.append(subagents_type_0_item)
+
+                return subagents_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[Agent | str] | None | Unset, data)
+
+        subagents = _parse_subagents(d.pop("subagents", UNSET))
+
+        def _parse_skills(data: object) -> list[Skill | str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                skills_type_0 = []
+                _skills_type_0 = data
+                for skills_type_0_item_data in _skills_type_0:
+
+                    def _parse_skills_type_0_item(data: object) -> Skill | str:
+                        try:
+                            if not isinstance(data, dict):
+                                raise TypeError()
+                            skills_type_0_item_type_1 = Skill.from_dict(data)
+
+                            return skills_type_0_item_type_1
+                        except (TypeError, ValueError, AttributeError, KeyError):
+                            pass
+                        return cast(Skill | str, data)
+
+                    skills_type_0_item = _parse_skills_type_0_item(skills_type_0_item_data)
+
+                    skills_type_0.append(skills_type_0_item)
+
+                return skills_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[Skill | str] | None | Unset, data)
+
+        skills = _parse_skills(d.pop("skills", UNSET))
+
+        agent = cls(
+            name=name,
+            description=description,
+            environments=environments,
+            model=model,
+            instructions=instructions,
+            subagents=subagents,
+            skills=skills,
+        )
+
+        agent.additional_properties = d
+        return agent
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/agent_record.py
+++ b/packages/sdk/src/agent_platform/models/agent_record.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+from uuid import UUID
+
+from dateutil.parser import isoparse
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.agent import Agent
+
+
+T = TypeVar("T", bound="AgentRecord")
+
+
+class AgentRecord(BaseModel):
+    """Catalog row exposing an ``Agent`` spec payload plus AgP metadata.
+
+    The catalog handle is ``spec.name``; callers reference it directly
+    via ``record.spec.name`` rather than a duplicated top-level field.
+
+        Attributes:
+            id (UUID):
+            spec (Agent): Declarative agent definition.
+            reserved (bool): True for H-owned rows; world-readable, write-locked behind employee_only.
+            created_at (datetime.datetime):
+            updated_at (datetime.datetime):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    id: UUID
+    spec: Agent
+    reserved: bool
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.agent import Agent
+
+        id = str(self.id)
+
+        spec = self.spec.to_dict()
+
+        reserved = self.reserved
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "id": id,
+                "spec": spec,
+                "reserved": reserved,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent import Agent
+
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        spec = Agent.from_dict(d.pop("spec"))
+
+        reserved = d.pop("reserved")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        agent_record = cls(
+            id=id,
+            spec=spec,
+            reserved=reserved,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        return agent_record

--- a/packages/sdk/src/agent_platform/models/browser.py
+++ b/packages/sdk/src/agent_platform/models/browser.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, Literal, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Browser")
+
+
+class Browser(BaseModel):
+    """Browser environment.
+
+    Attributes:
+        id (str): Catalog id.
+        headless (bool): Run without a visible window.
+        width (int): Viewport width in pixels.
+        height (int): Viewport height in pixels.
+        start_url (None | str): Initial URL.
+        kind (Literal['web'] | Unset):  Default: 'web'.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    id: str
+    headless: bool
+    width: int
+    height: int
+    start_url: None | str
+    kind: Literal["web"] | Unset = "web"
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        headless = self.headless
+
+        width = self.width
+
+        height = self.height
+
+        start_url: None | str
+        start_url = self.start_url
+
+        kind = self.kind
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "id": id,
+                "headless": headless,
+                "width": width,
+                "height": height,
+                "start_url": start_url,
+            }
+        )
+        if kind is not UNSET:
+            field_dict["kind"] = kind
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        headless = d.pop("headless")
+
+        width = d.pop("width")
+
+        height = d.pop("height")
+
+        def _parse_start_url(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        start_url = _parse_start_url(d.pop("start_url"))
+
+        kind = cast(Literal["web"] | Unset, d.pop("kind", UNSET))
+        if kind != "web" and not isinstance(kind, Unset):
+            raise ValueError(f"kind must match const 'web', got '{kind}'")
+
+        browser = cls(
+            id=id,
+            headless=headless,
+            width=width,
+            height=height,
+            start_url=start_url,
+            kind=kind,
+        )
+
+        return browser

--- a/packages/sdk/src/agent_platform/models/code_sandbox.py
+++ b/packages/sdk/src/agent_platform/models/code_sandbox.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, Literal, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.code_sandbox_env import CodeSandboxEnv
+    from ..models.mcp_server import MCPServer
+
+
+T = TypeVar("T", bound="CodeSandbox")
+
+
+class CodeSandbox(BaseModel):
+    """Code sandbox environment.
+
+    Attributes:
+        id (str): Catalog id.
+        kind (Literal['code'] | Unset):  Default: 'code'.
+        pip_packages (list[str] | Unset): Pip packages installed at provision time.
+        env (CodeSandboxEnv | Unset): Environment variables.
+        mcp_servers (list[MCPServer] | Unset): MCP servers reachable from the sandbox.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    id: str
+    kind: Literal["code"] | Unset = "code"
+    pip_packages: list[str] | Unset = UNSET
+    env: CodeSandboxEnv | Unset = UNSET
+    mcp_servers: list[MCPServer] | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.code_sandbox_env import CodeSandboxEnv
+        from ..models.mcp_server import MCPServer
+
+        id = self.id
+
+        kind = self.kind
+
+        pip_packages: list[str] | Unset = UNSET
+        if not isinstance(self.pip_packages, Unset):
+            pip_packages = self.pip_packages
+
+        env: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.env, Unset):
+            env = self.env.to_dict()
+
+        mcp_servers: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.mcp_servers, Unset):
+            mcp_servers = []
+            for mcp_servers_item_data in self.mcp_servers:
+                mcp_servers_item = mcp_servers_item_data.to_dict()
+                mcp_servers.append(mcp_servers_item)
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "id": id,
+            }
+        )
+        if kind is not UNSET:
+            field_dict["kind"] = kind
+        if pip_packages is not UNSET:
+            field_dict["pip_packages"] = pip_packages
+        if env is not UNSET:
+            field_dict["env"] = env
+        if mcp_servers is not UNSET:
+            field_dict["mcp_servers"] = mcp_servers
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.code_sandbox_env import CodeSandboxEnv
+        from ..models.mcp_server import MCPServer
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        kind = cast(Literal["code"] | Unset, d.pop("kind", UNSET))
+        if kind != "code" and not isinstance(kind, Unset):
+            raise ValueError(f"kind must match const 'code', got '{kind}'")
+
+        pip_packages = cast(list[str], d.pop("pip_packages", UNSET))
+
+        _env = d.pop("env", UNSET)
+        env: CodeSandboxEnv | Unset
+        if isinstance(_env, Unset):
+            env = UNSET
+        else:
+            env = CodeSandboxEnv.from_dict(_env)
+
+        _mcp_servers = d.pop("mcp_servers", UNSET)
+        mcp_servers: list[MCPServer] | Unset = UNSET
+        if _mcp_servers is not UNSET:
+            mcp_servers = []
+            for mcp_servers_item_data in _mcp_servers:
+                mcp_servers_item = MCPServer.from_dict(mcp_servers_item_data)
+
+                mcp_servers.append(mcp_servers_item)
+
+        code_sandbox = cls(
+            id=id,
+            kind=kind,
+            pip_packages=pip_packages,
+            env=env,
+            mcp_servers=mcp_servers,
+        )
+
+        return code_sandbox

--- a/packages/sdk/src/agent_platform/models/code_sandbox_env.py
+++ b/packages/sdk/src/agent_platform/models/code_sandbox_env.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CodeSandboxEnv")
+
+
+class CodeSandboxEnv(BaseModel):
+    """Environment variables."""
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    additional_properties: dict[str, str] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        code_sandbox_env = cls()
+
+        code_sandbox_env.additional_properties = d
+        return code_sandbox_env
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/create_agent.py
+++ b/packages/sdk/src/agent_platform/models/create_agent.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.agent import Agent
+
+
+T = TypeVar("T", bound="CreateAgent")
+
+
+class CreateAgent(BaseModel):
+    """``POST /api/v2/agents`` body.
+
+    Attributes:
+        spec (Agent): Declarative agent definition.
+        reserved (bool | Unset): H employees only; rejected with 403 otherwise. Default: False.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    spec: Agent
+    reserved: bool | Unset = False
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.agent import Agent
+
+        spec = self.spec.to_dict()
+
+        reserved = self.reserved
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "spec": spec,
+            }
+        )
+        if reserved is not UNSET:
+            field_dict["reserved"] = reserved
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent import Agent
+
+        d = dict(src_dict)
+        spec = Agent.from_dict(d.pop("spec"))
+
+        reserved = d.pop("reserved", UNSET)
+
+        create_agent = cls(
+            spec=spec,
+            reserved=reserved,
+        )
+
+        return create_agent

--- a/packages/sdk/src/agent_platform/models/create_environment.py
+++ b/packages/sdk/src/agent_platform/models/create_environment.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.browser import Browser
+    from ..models.code_sandbox import CodeSandbox
+    from ..models.mcp import MCP
+    from ..models.memory import Memory
+
+
+T = TypeVar("T", bound="CreateEnvironment")
+
+
+class CreateEnvironment(BaseModel):
+    """``POST /api/v2/environments`` body.
+
+    Attributes:
+        spec (Browser | CodeSandbox | MCP | Memory):
+        description (str | Unset):  Default: ''.
+        reserved (bool | Unset): H employees only; rejected with 403 otherwise. Default: False.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    spec: Browser | CodeSandbox | MCP | Memory
+    description: str | Unset = ""
+    reserved: bool | Unset = False
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.browser import Browser
+        from ..models.code_sandbox import CodeSandbox
+        from ..models.mcp import MCP
+        from ..models.memory import Memory
+
+        spec: dict[str, Any]
+        if isinstance(self.spec, Browser):
+            spec = self.spec.to_dict()
+        elif isinstance(self.spec, CodeSandbox):
+            spec = self.spec.to_dict()
+        elif isinstance(self.spec, MCP):
+            spec = self.spec.to_dict()
+        else:
+            spec = self.spec.to_dict()
+
+        description = self.description
+
+        reserved = self.reserved
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "spec": spec,
+            }
+        )
+        if description is not UNSET:
+            field_dict["description"] = description
+        if reserved is not UNSET:
+            field_dict["reserved"] = reserved
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.browser import Browser
+        from ..models.code_sandbox import CodeSandbox
+        from ..models.mcp import MCP
+        from ..models.memory import Memory
+
+        d = dict(src_dict)
+
+        def _parse_spec(data: object) -> Browser | CodeSandbox | MCP | Memory:
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                spec_type_0 = Browser.from_dict(data)
+
+                return spec_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                spec_type_1 = CodeSandbox.from_dict(data)
+
+                return spec_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                spec_type_2 = MCP.from_dict(data)
+
+                return spec_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            if not isinstance(data, dict):
+                raise TypeError()
+            spec_type_3 = Memory.from_dict(data)
+
+            return spec_type_3
+
+        spec = _parse_spec(d.pop("spec"))
+
+        description = d.pop("description", UNSET)
+
+        reserved = d.pop("reserved", UNSET)
+
+        create_environment = cls(
+            spec=spec,
+            description=description,
+            reserved=reserved,
+        )
+
+        return create_environment

--- a/packages/sdk/src/agent_platform/models/create_memory.py
+++ b/packages/sdk/src/agent_platform/models/create_memory.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CreateMemory")
+
+
+class CreateMemory(BaseModel):
+    """Upsert a memory by ``(org_id, namespace, key)``.
+
+    Attributes:
+        namespace (str):
+        key (str):
+        value (str):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    namespace: str
+    key: str
+    value: str
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        namespace = self.namespace
+
+        key = self.key
+
+        value = self.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "namespace": namespace,
+                "key": key,
+                "value": value,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        namespace = d.pop("namespace")
+
+        key = d.pop("key")
+
+        value = d.pop("value")
+
+        create_memory = cls(
+            namespace=namespace,
+            key=key,
+            value=value,
+        )
+
+        create_memory.additional_properties = d
+        return create_memory
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/create_skill.py
+++ b/packages/sdk/src/agent_platform/models/create_skill.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CreateSkill")
+
+
+class CreateSkill(BaseModel):
+    """Request to create a skill.
+
+    Attributes:
+        name (str): Kebab-case stable handle the agent uses to reference this skill.
+        description (str): One-line routing hint shown in the skill catalog.
+        body (str | Unset): Markdown prompt fragment. Required unless `uri` is set. Default: ''.
+        source (None | str | Unset): Provenance URL.
+        url_pattern (None | str | Unset): Inject only when an observation URL matches this regex. Mutually exclusive
+            with `uri`.
+        uri (None | str | Unset): Fetch body on demand from this location. Mutually exclusive with `url_pattern`.
+        reserved (bool | Unset): H employees only; rejected with 403 otherwise. Reserved rows are world-readable.
+            Default: False.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    name: str
+    description: str
+    body: str | Unset = ""
+    source: None | str | Unset = UNSET
+    url_pattern: None | str | Unset = UNSET
+    uri: None | str | Unset = UNSET
+    reserved: bool | Unset = False
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        description = self.description
+
+        body = self.body
+
+        source: None | str | Unset
+        if isinstance(self.source, Unset):
+            source = UNSET
+        else:
+            source = self.source
+
+        url_pattern: None | str | Unset
+        if isinstance(self.url_pattern, Unset):
+            url_pattern = UNSET
+        else:
+            url_pattern = self.url_pattern
+
+        uri: None | str | Unset
+        if isinstance(self.uri, Unset):
+            uri = UNSET
+        else:
+            uri = self.uri
+
+        reserved = self.reserved
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+                "description": description,
+            }
+        )
+        if body is not UNSET:
+            field_dict["body"] = body
+        if source is not UNSET:
+            field_dict["source"] = source
+        if url_pattern is not UNSET:
+            field_dict["url_pattern"] = url_pattern
+        if uri is not UNSET:
+            field_dict["uri"] = uri
+        if reserved is not UNSET:
+            field_dict["reserved"] = reserved
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        description = d.pop("description")
+
+        body = d.pop("body", UNSET)
+
+        def _parse_source(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        source = _parse_source(d.pop("source", UNSET))
+
+        def _parse_url_pattern(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        url_pattern = _parse_url_pattern(d.pop("url_pattern", UNSET))
+
+        def _parse_uri(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        uri = _parse_uri(d.pop("uri", UNSET))
+
+        reserved = d.pop("reserved", UNSET)
+
+        create_skill = cls(
+            name=name,
+            description=description,
+            body=body,
+            source=source,
+            url_pattern=url_pattern,
+            uri=uri,
+            reserved=reserved,
+        )
+
+        create_skill.additional_properties = d
+        return create_skill
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/environment_record.py
+++ b/packages/sdk/src/agent_platform/models/environment_record.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+from uuid import UUID
+
+from dateutil.parser import isoparse
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.browser import Browser
+    from ..models.code_sandbox import CodeSandbox
+    from ..models.mcp import MCP
+    from ..models.memory import Memory
+
+
+T = TypeVar("T", bound="EnvironmentRecord")
+
+
+class EnvironmentRecord(BaseModel):
+    """Catalog row exposing an ``Environment`` spec plus AgP metadata.
+
+    The catalog handle is ``spec.id``; callers reference it directly via
+    ``record.spec.id`` rather than a duplicated top-level field.
+
+        Attributes:
+            id (UUID):
+            spec (Browser | CodeSandbox | MCP | Memory): Discriminated by ``kind``.
+            reserved (bool): True for H-owned rows; world-readable, write-locked behind employee_only.
+            created_at (datetime.datetime):
+            updated_at (datetime.datetime):
+            description (str | Unset):  Default: ''.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    id: UUID
+    spec: Browser | CodeSandbox | MCP | Memory
+    reserved: bool
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    description: str | Unset = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.browser import Browser
+        from ..models.code_sandbox import CodeSandbox
+        from ..models.mcp import MCP
+        from ..models.memory import Memory
+
+        id = str(self.id)
+
+        spec: dict[str, Any]
+        if isinstance(self.spec, Browser):
+            spec = self.spec.to_dict()
+        elif isinstance(self.spec, CodeSandbox):
+            spec = self.spec.to_dict()
+        elif isinstance(self.spec, MCP):
+            spec = self.spec.to_dict()
+        else:
+            spec = self.spec.to_dict()
+
+        reserved = self.reserved
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        description = self.description
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "id": id,
+                "spec": spec,
+                "reserved": reserved,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+        if description is not UNSET:
+            field_dict["description"] = description
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.browser import Browser
+        from ..models.code_sandbox import CodeSandbox
+        from ..models.mcp import MCP
+        from ..models.memory import Memory
+
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        def _parse_spec(data: object) -> Browser | CodeSandbox | MCP | Memory:
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                spec_type_0 = Browser.from_dict(data)
+
+                return spec_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                spec_type_1 = CodeSandbox.from_dict(data)
+
+                return spec_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                spec_type_2 = MCP.from_dict(data)
+
+                return spec_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            if not isinstance(data, dict):
+                raise TypeError()
+            spec_type_3 = Memory.from_dict(data)
+
+            return spec_type_3
+
+        spec = _parse_spec(d.pop("spec"))
+
+        reserved = d.pop("reserved")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        description = d.pop("description", UNSET)
+
+        environment_record = cls(
+            id=id,
+            spec=spec,
+            reserved=reserved,
+            created_at=created_at,
+            updated_at=updated_at,
+            description=description,
+        )
+
+        return environment_record

--- a/packages/sdk/src/agent_platform/models/feedback.py
+++ b/packages/sdk/src/agent_platform/models/feedback.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Feedback")
+
+
+class Feedback(BaseModel):
+    """Feedback on the semantic success of the trajectory.
+
+    Attributes:
+        success (bool):
+        message (None | str | Unset):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    success: bool
+    message: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        success = self.success
+
+        message: None | str | Unset
+        if isinstance(self.message, Unset):
+            message = UNSET
+        else:
+            message = self.message
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "success": success,
+            }
+        )
+        if message is not UNSET:
+            field_dict["message"] = message
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        success = d.pop("success")
+
+        def _parse_message(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        message = _parse_message(d.pop("message", UNSET))
+
+        feedback = cls(
+            success=success,
+            message=message,
+        )
+
+        feedback.additional_properties = d
+        return feedback
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/http_validation_error.py
+++ b/packages/sdk/src/agent_platform/models/http_validation_error.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.validation_error import ValidationError
+
+
+T = TypeVar("T", bound="HTTPValidationError")
+
+
+class HTTPValidationError(BaseModel):
+    """
+    Attributes:
+        detail (list[ValidationError] | Unset):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    detail: list[ValidationError] | Unset = UNSET
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.validation_error import ValidationError
+
+        detail: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.detail, Unset):
+            detail = []
+            for detail_item_data in self.detail:
+                detail_item = detail_item_data.to_dict()
+                detail.append(detail_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if detail is not UNSET:
+            field_dict["detail"] = detail
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.validation_error import ValidationError
+
+        d = dict(src_dict)
+        _detail = d.pop("detail", UNSET)
+        detail: list[ValidationError] | Unset = UNSET
+        if _detail is not UNSET:
+            detail = []
+            for detail_item_data in _detail:
+                detail_item = ValidationError.from_dict(detail_item_data)
+
+                detail.append(detail_item)
+
+        http_validation_error = cls(
+            detail=detail,
+        )
+
+        http_validation_error.additional_properties = d
+        return http_validation_error
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/list_agents_sort_type_0_item.py
+++ b/packages/sdk/src/agent_platform/models/list_agents_sort_type_0_item.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class ListAgentsSortType0Item(str, Enum):
+    AGENT_IDENTIFIER = "agent_identifier"
+    CREATED_AT = "created_at"
+    VALUE_1 = "-created_at"
+    VALUE_3 = "-agent_identifier"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/sdk/src/agent_platform/models/list_environments_sort_type_0_item.py
+++ b/packages/sdk/src/agent_platform/models/list_environments_sort_type_0_item.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class ListEnvironmentsSortType0Item(str, Enum):
+    CREATED_AT = "created_at"
+    ENV_IDENTIFIER = "env_identifier"
+    VALUE_1 = "-created_at"
+    VALUE_3 = "-env_identifier"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/sdk/src/agent_platform/models/list_memories_sort_type_0_item.py
+++ b/packages/sdk/src/agent_platform/models/list_memories_sort_type_0_item.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class ListMemoriesSortType0Item(str, Enum):
+    UPDATED_AT = "updated_at"
+    VALUE_1 = "-updated_at"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/sdk/src/agent_platform/models/list_session_events_sort_type_0_item.py
+++ b/packages/sdk/src/agent_platform/models/list_session_events_sort_type_0_item.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class ListSessionEventsSortType0Item(str, Enum):
+    TIMESTAMP = "timestamp"
+    VALUE_1 = "-timestamp"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/sdk/src/agent_platform/models/list_sessions_owner.py
+++ b/packages/sdk/src/agent_platform/models/list_sessions_owner.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class ListSessionsOwner(str, Enum):
+    ME = "me"
+    ME_IN_ORGANIZATION = "me-in-organization"
+    ME_OR_ORGANIZATION = "me-or-organization"
+    ORGANIZATION = "organization"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/sdk/src/agent_platform/models/list_sessions_sort_type_0_item.py
+++ b/packages/sdk/src/agent_platform/models/list_sessions_sort_type_0_item.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class ListSessionsSortType0Item(str, Enum):
+    CREATED_AT = "created_at"
+    VALUE_1 = "-created_at"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/sdk/src/agent_platform/models/list_skills_sort_type_0_item.py
+++ b/packages/sdk/src/agent_platform/models/list_skills_sort_type_0_item.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class ListSkillsSortType0Item(str, Enum):
+    CREATED_AT = "created_at"
+    NAME = "name"
+    VALUE_1 = "-created_at"
+    VALUE_3 = "-name"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/sdk/src/agent_platform/models/mcp.py
+++ b/packages/sdk/src/agent_platform/models/mcp.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, Literal, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.mcp_server import MCPServer
+
+
+T = TypeVar("T", bound="MCP")
+
+
+class MCP(BaseModel):
+    """MCP environment.
+
+    Attributes:
+        id (str): Catalog id.
+        servers (list[MCPServer]): At least one MCP server.
+        kind (Literal['mcp'] | Unset):  Default: 'mcp'.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    id: str
+    servers: list[MCPServer]
+    kind: Literal["mcp"] | Unset = "mcp"
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.mcp_server import MCPServer
+
+        id = self.id
+
+        servers = []
+        for servers_item_data in self.servers:
+            servers_item = servers_item_data.to_dict()
+            servers.append(servers_item)
+
+        kind = self.kind
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "id": id,
+                "servers": servers,
+            }
+        )
+        if kind is not UNSET:
+            field_dict["kind"] = kind
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.mcp_server import MCPServer
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        servers = []
+        _servers = d.pop("servers")
+        for servers_item_data in _servers:
+            servers_item = MCPServer.from_dict(servers_item_data)
+
+            servers.append(servers_item)
+
+        kind = cast(Literal["mcp"] | Unset, d.pop("kind", UNSET))
+        if kind != "mcp" and not isinstance(kind, Unset):
+            raise ValueError(f"kind must match const 'mcp', got '{kind}'")
+
+        mcp = cls(
+            id=id,
+            servers=servers,
+            kind=kind,
+        )
+
+        return mcp

--- a/packages/sdk/src/agent_platform/models/mcp_server.py
+++ b/packages/sdk/src/agent_platform/models/mcp_server.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..models.mcp_server_transport import MCPServerTransport
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.mcp_server_env import MCPServerEnv
+    from ..models.mcp_server_headers import MCPServerHeaders
+
+
+T = TypeVar("T", bound="MCPServer")
+
+
+class MCPServer(BaseModel):
+    """MCP server attached to an environment.
+
+    Attributes:
+        name (str): Stable identifier.
+        transport (MCPServerTransport): MCP transport.
+        command (None | str | Unset): Subprocess executable (stdio).
+        args (list[str] | Unset): Subprocess argv tail (stdio).
+        env (MCPServerEnv | Unset): Subprocess env vars (stdio).
+        url (None | str | Unset): Endpoint URL (HTTP).
+        headers (MCPServerHeaders | Unset): Request headers (HTTP).
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    name: str
+    transport: MCPServerTransport
+    command: None | str | Unset = UNSET
+    args: list[str] | Unset = UNSET
+    env: MCPServerEnv | Unset = UNSET
+    url: None | str | Unset = UNSET
+    headers: MCPServerHeaders | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.mcp_server_env import MCPServerEnv
+        from ..models.mcp_server_headers import MCPServerHeaders
+
+        name = self.name
+
+        transport = self.transport.value
+
+        command: None | str | Unset
+        if isinstance(self.command, Unset):
+            command = UNSET
+        else:
+            command = self.command
+
+        args: list[str] | Unset = UNSET
+        if not isinstance(self.args, Unset):
+            args = self.args
+
+        env: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.env, Unset):
+            env = self.env.to_dict()
+
+        url: None | str | Unset
+        if isinstance(self.url, Unset):
+            url = UNSET
+        else:
+            url = self.url
+
+        headers: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.headers, Unset):
+            headers = self.headers.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "name": name,
+                "transport": transport,
+            }
+        )
+        if command is not UNSET:
+            field_dict["command"] = command
+        if args is not UNSET:
+            field_dict["args"] = args
+        if env is not UNSET:
+            field_dict["env"] = env
+        if url is not UNSET:
+            field_dict["url"] = url
+        if headers is not UNSET:
+            field_dict["headers"] = headers
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.mcp_server_env import MCPServerEnv
+        from ..models.mcp_server_headers import MCPServerHeaders
+
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        transport = MCPServerTransport(d.pop("transport"))
+
+        def _parse_command(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        command = _parse_command(d.pop("command", UNSET))
+
+        args = cast(list[str], d.pop("args", UNSET))
+
+        _env = d.pop("env", UNSET)
+        env: MCPServerEnv | Unset
+        if isinstance(_env, Unset):
+            env = UNSET
+        else:
+            env = MCPServerEnv.from_dict(_env)
+
+        def _parse_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        url = _parse_url(d.pop("url", UNSET))
+
+        _headers = d.pop("headers", UNSET)
+        headers: MCPServerHeaders | Unset
+        if isinstance(_headers, Unset):
+            headers = UNSET
+        else:
+            headers = MCPServerHeaders.from_dict(_headers)
+
+        mcp_server = cls(
+            name=name,
+            transport=transport,
+            command=command,
+            args=args,
+            env=env,
+            url=url,
+            headers=headers,
+        )
+
+        return mcp_server

--- a/packages/sdk/src/agent_platform/models/mcp_server_env.py
+++ b/packages/sdk/src/agent_platform/models/mcp_server_env.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="MCPServerEnv")
+
+
+class MCPServerEnv(BaseModel):
+    """Subprocess env vars (stdio)."""
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    additional_properties: dict[str, str] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        mcp_server_env = cls()
+
+        mcp_server_env.additional_properties = d
+        return mcp_server_env
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/mcp_server_headers.py
+++ b/packages/sdk/src/agent_platform/models/mcp_server_headers.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="MCPServerHeaders")
+
+
+class MCPServerHeaders(BaseModel):
+    """Request headers (HTTP)."""
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    additional_properties: dict[str, str] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        mcp_server_headers = cls()
+
+        mcp_server_headers.additional_properties = d
+        return mcp_server_headers
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/mcp_server_transport.py
+++ b/packages/sdk/src/agent_platform/models/mcp_server_transport.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class MCPServerTransport(str, Enum):
+    SSE = "sse"
+    STDIO = "stdio"
+    STREAMABLE_HTTP = "streamable_http"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/sdk/src/agent_platform/models/memory.py
+++ b/packages/sdk/src/agent_platform/models/memory.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, Literal, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Memory")
+
+
+class Memory(BaseModel):
+    """Cross-session key-value memory backed by AgP.
+
+    Attributes:
+        id (str): Catalog id.
+        namespace (str): Memory namespace; scope for keys across sessions.
+        kind (Literal['memory'] | Unset):  Default: 'memory'.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    id: str
+    namespace: str
+    kind: Literal["memory"] | Unset = "memory"
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        namespace = self.namespace
+
+        kind = self.kind
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "id": id,
+                "namespace": namespace,
+            }
+        )
+        if kind is not UNSET:
+            field_dict["kind"] = kind
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        namespace = d.pop("namespace")
+
+        kind = cast(Literal["memory"] | Unset, d.pop("kind", UNSET))
+        if kind != "memory" and not isinstance(kind, Unset):
+            raise ValueError(f"kind must match const 'memory', got '{kind}'")
+
+        memory = cls(
+            id=id,
+            namespace=namespace,
+            kind=kind,
+        )
+
+        return memory

--- a/packages/sdk/src/agent_platform/models/memory_record.py
+++ b/packages/sdk/src/agent_platform/models/memory_record.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+from uuid import UUID
+
+from dateutil.parser import isoparse
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="MemoryRecord")
+
+
+class MemoryRecord(BaseModel):
+    """Persistent KV entry scoped to ``(org_id, namespace, key)``.
+
+    Attributes:
+        id (UUID):
+        namespace (str):
+        key (str):
+        value (str):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    id: UUID
+    namespace: str
+    key: str
+    value: str
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        namespace = self.namespace
+
+        key = self.key
+
+        value = self.value
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "namespace": namespace,
+                "key": key,
+                "value": value,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        namespace = d.pop("namespace")
+
+        key = d.pop("key")
+
+        value = d.pop("value")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        memory_record = cls(
+            id=id,
+            namespace=namespace,
+            key=key,
+            value=value,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        memory_record.additional_properties = d
+        return memory_record
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/metrics.py
+++ b/packages/sdk/src/agent_platform/models/metrics.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.model_cost import ModelCost
+
+
+T = TypeVar("T", bound="Metrics")
+
+
+class Metrics(BaseModel):
+    """Metrics for a trajectory.
+
+    Attributes:
+        steps (int | Unset):  Default: 0.
+        cost_per_model (list[ModelCost] | Unset):
+        input_cost (float | None | Unset):
+        output_cost (float | None | Unset):
+        reasoning_cost (float | None | Unset):
+        total_cost (float | None | Unset):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    steps: int | Unset = 0
+    cost_per_model: list[ModelCost] | Unset = UNSET
+    input_cost: float | None | Unset = UNSET
+    output_cost: float | None | Unset = UNSET
+    reasoning_cost: float | None | Unset = UNSET
+    total_cost: float | None | Unset = UNSET
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.model_cost import ModelCost
+
+        steps = self.steps
+
+        cost_per_model: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.cost_per_model, Unset):
+            cost_per_model = []
+            for cost_per_model_item_data in self.cost_per_model:
+                cost_per_model_item = cost_per_model_item_data.to_dict()
+                cost_per_model.append(cost_per_model_item)
+
+        input_cost: float | None | Unset
+        if isinstance(self.input_cost, Unset):
+            input_cost = UNSET
+        else:
+            input_cost = self.input_cost
+
+        output_cost: float | None | Unset
+        if isinstance(self.output_cost, Unset):
+            output_cost = UNSET
+        else:
+            output_cost = self.output_cost
+
+        reasoning_cost: float | None | Unset
+        if isinstance(self.reasoning_cost, Unset):
+            reasoning_cost = UNSET
+        else:
+            reasoning_cost = self.reasoning_cost
+
+        total_cost: float | None | Unset
+        if isinstance(self.total_cost, Unset):
+            total_cost = UNSET
+        else:
+            total_cost = self.total_cost
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if steps is not UNSET:
+            field_dict["steps"] = steps
+        if cost_per_model is not UNSET:
+            field_dict["cost_per_model"] = cost_per_model
+        if input_cost is not UNSET:
+            field_dict["input_cost"] = input_cost
+        if output_cost is not UNSET:
+            field_dict["output_cost"] = output_cost
+        if reasoning_cost is not UNSET:
+            field_dict["reasoning_cost"] = reasoning_cost
+        if total_cost is not UNSET:
+            field_dict["total_cost"] = total_cost
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.model_cost import ModelCost
+
+        d = dict(src_dict)
+        steps = d.pop("steps", UNSET)
+
+        _cost_per_model = d.pop("cost_per_model", UNSET)
+        cost_per_model: list[ModelCost] | Unset = UNSET
+        if _cost_per_model is not UNSET:
+            cost_per_model = []
+            for cost_per_model_item_data in _cost_per_model:
+                cost_per_model_item = ModelCost.from_dict(cost_per_model_item_data)
+
+                cost_per_model.append(cost_per_model_item)
+
+        def _parse_input_cost(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        input_cost = _parse_input_cost(d.pop("input_cost", UNSET))
+
+        def _parse_output_cost(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        output_cost = _parse_output_cost(d.pop("output_cost", UNSET))
+
+        def _parse_reasoning_cost(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        reasoning_cost = _parse_reasoning_cost(d.pop("reasoning_cost", UNSET))
+
+        def _parse_total_cost(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        total_cost = _parse_total_cost(d.pop("total_cost", UNSET))
+
+        metrics = cls(
+            steps=steps,
+            cost_per_model=cost_per_model,
+            input_cost=input_cost,
+            output_cost=output_cost,
+            reasoning_cost=reasoning_cost,
+            total_cost=total_cost,
+        )
+
+        metrics.additional_properties = d
+        return metrics
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/model_cost.py
+++ b/packages/sdk/src/agent_platform/models/model_cost.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ModelCost")
+
+
+class ModelCost(BaseModel):
+    """Cost for a model.
+
+    Attributes:
+        name (str):
+        input_tokens (int):
+        output_tokens (int):
+        reasoning_tokens (int):
+        input_cost (float | None | Unset):
+        output_cost (float | None | Unset):
+        reasoning_cost (float | None | Unset):
+        total_cost (float | None | Unset):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    name: str
+    input_tokens: int
+    output_tokens: int
+    reasoning_tokens: int
+    input_cost: float | None | Unset = UNSET
+    output_cost: float | None | Unset = UNSET
+    reasoning_cost: float | None | Unset = UNSET
+    total_cost: float | None | Unset = UNSET
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        input_tokens = self.input_tokens
+
+        output_tokens = self.output_tokens
+
+        reasoning_tokens = self.reasoning_tokens
+
+        input_cost: float | None | Unset
+        if isinstance(self.input_cost, Unset):
+            input_cost = UNSET
+        else:
+            input_cost = self.input_cost
+
+        output_cost: float | None | Unset
+        if isinstance(self.output_cost, Unset):
+            output_cost = UNSET
+        else:
+            output_cost = self.output_cost
+
+        reasoning_cost: float | None | Unset
+        if isinstance(self.reasoning_cost, Unset):
+            reasoning_cost = UNSET
+        else:
+            reasoning_cost = self.reasoning_cost
+
+        total_cost: float | None | Unset
+        if isinstance(self.total_cost, Unset):
+            total_cost = UNSET
+        else:
+            total_cost = self.total_cost
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "reasoning_tokens": reasoning_tokens,
+            }
+        )
+        if input_cost is not UNSET:
+            field_dict["input_cost"] = input_cost
+        if output_cost is not UNSET:
+            field_dict["output_cost"] = output_cost
+        if reasoning_cost is not UNSET:
+            field_dict["reasoning_cost"] = reasoning_cost
+        if total_cost is not UNSET:
+            field_dict["total_cost"] = total_cost
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        input_tokens = d.pop("input_tokens")
+
+        output_tokens = d.pop("output_tokens")
+
+        reasoning_tokens = d.pop("reasoning_tokens")
+
+        def _parse_input_cost(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        input_cost = _parse_input_cost(d.pop("input_cost", UNSET))
+
+        def _parse_output_cost(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        output_cost = _parse_output_cost(d.pop("output_cost", UNSET))
+
+        def _parse_reasoning_cost(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        reasoning_cost = _parse_reasoning_cost(d.pop("reasoning_cost", UNSET))
+
+        def _parse_total_cost(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        total_cost = _parse_total_cost(d.pop("total_cost", UNSET))
+
+        model_cost = cls(
+            name=name,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            reasoning_tokens=reasoning_tokens,
+            input_cost=input_cost,
+            output_cost=output_cost,
+            reasoning_cost=reasoning_cost,
+            total_cost=total_cost,
+        )
+
+        model_cost.additional_properties = d
+        return model_cost
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/model_usage.py
+++ b/packages/sdk/src/agent_platform/models/model_usage.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ModelUsage")
+
+
+class ModelUsage(BaseModel):
+    """Per-model token usage.
+
+    Attributes:
+        name (str):
+        input_tokens (int):
+        output_tokens (int):
+        reasoning_tokens (int):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    name: str
+    input_tokens: int
+    output_tokens: int
+    reasoning_tokens: int
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        input_tokens = self.input_tokens
+
+        output_tokens = self.output_tokens
+
+        reasoning_tokens = self.reasoning_tokens
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "reasoning_tokens": reasoning_tokens,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        input_tokens = d.pop("input_tokens")
+
+        output_tokens = d.pop("output_tokens")
+
+        reasoning_tokens = d.pop("reasoning_tokens")
+
+        model_usage = cls(
+            name=name,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            reasoning_tokens=reasoning_tokens,
+        )
+
+        model_usage.additional_properties = d
+        return model_usage
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/page_agent_record.py
+++ b/packages/sdk/src/agent_platform/models/page_agent_record.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.agent_record import AgentRecord
+
+
+T = TypeVar("T", bound="PageAgentRecord")
+
+
+class PageAgentRecord(BaseModel):
+    """
+    Attributes:
+        items (list[AgentRecord]):
+        total (int):
+        page (int):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    items: list[AgentRecord]
+    total: int
+    page: int
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.agent_record import AgentRecord
+
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        total = self.total
+
+        page = self.page
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "items": items,
+                "total": total,
+                "page": page,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent_record import AgentRecord
+
+        d = dict(src_dict)
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = AgentRecord.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        total = d.pop("total")
+
+        page = d.pop("page")
+
+        page_agent_record = cls(
+            items=items,
+            total=total,
+            page=page,
+        )
+
+        page_agent_record.additional_properties = d
+        return page_agent_record
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/page_environment_record.py
+++ b/packages/sdk/src/agent_platform/models/page_environment_record.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.environment_record import EnvironmentRecord
+
+
+T = TypeVar("T", bound="PageEnvironmentRecord")
+
+
+class PageEnvironmentRecord(BaseModel):
+    """
+    Attributes:
+        items (list[EnvironmentRecord]):
+        total (int):
+        page (int):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    items: list[EnvironmentRecord]
+    total: int
+    page: int
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.environment_record import EnvironmentRecord
+
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        total = self.total
+
+        page = self.page
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "items": items,
+                "total": total,
+                "page": page,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.environment_record import EnvironmentRecord
+
+        d = dict(src_dict)
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = EnvironmentRecord.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        total = d.pop("total")
+
+        page = d.pop("page")
+
+        page_environment_record = cls(
+            items=items,
+            total=total,
+            page=page,
+        )
+
+        page_environment_record.additional_properties = d
+        return page_environment_record
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/page_memory_record.py
+++ b/packages/sdk/src/agent_platform/models/page_memory_record.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.memory_record import MemoryRecord
+
+
+T = TypeVar("T", bound="PageMemoryRecord")
+
+
+class PageMemoryRecord(BaseModel):
+    """
+    Attributes:
+        items (list[MemoryRecord]):
+        total (int):
+        page (int):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    items: list[MemoryRecord]
+    total: int
+    page: int
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.memory_record import MemoryRecord
+
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        total = self.total
+
+        page = self.page
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "items": items,
+                "total": total,
+                "page": page,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.memory_record import MemoryRecord
+
+        d = dict(src_dict)
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = MemoryRecord.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        total = d.pop("total")
+
+        page = d.pop("page")
+
+        page_memory_record = cls(
+            items=items,
+            total=total,
+            page=page,
+        )
+
+        page_memory_record.additional_properties = d
+        return page_memory_record
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/page_session_summary.py
+++ b/packages/sdk/src/agent_platform/models/page_session_summary.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.session_summary import SessionSummary
+
+
+T = TypeVar("T", bound="PageSessionSummary")
+
+
+class PageSessionSummary(BaseModel):
+    """
+    Attributes:
+        items (list[SessionSummary]):
+        total (int):
+        page (int):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    items: list[SessionSummary]
+    total: int
+    page: int
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.session_summary import SessionSummary
+
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        total = self.total
+
+        page = self.page
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "items": items,
+                "total": total,
+                "page": page,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.session_summary import SessionSummary
+
+        d = dict(src_dict)
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = SessionSummary.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        total = d.pop("total")
+
+        page = d.pop("page")
+
+        page_session_summary = cls(
+            items=items,
+            total=total,
+            page=page,
+        )
+
+        page_session_summary.additional_properties = d
+        return page_session_summary
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/page_skill_record.py
+++ b/packages/sdk/src/agent_platform/models/page_skill_record.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.skill_record import SkillRecord
+
+
+T = TypeVar("T", bound="PageSkillRecord")
+
+
+class PageSkillRecord(BaseModel):
+    """
+    Attributes:
+        items (list[SkillRecord]):
+        total (int):
+        page (int):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    items: list[SkillRecord]
+    total: int
+    page: int
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.skill_record import SkillRecord
+
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        total = self.total
+
+        page = self.page
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "items": items,
+                "total": total,
+                "page": page,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.skill_record import SkillRecord
+
+        d = dict(src_dict)
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = SkillRecord.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        total = d.pop("total")
+
+        page = d.pop("page")
+
+        page_skill_record = cls(
+            items=items,
+            total=total,
+            page=page,
+        )
+
+        page_skill_record.additional_properties = d
+        return page_skill_record
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/page_trajectory_event.py
+++ b/packages/sdk/src/agent_platform/models/page_trajectory_event.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.trajectory_event import TrajectoryEvent
+
+
+T = TypeVar("T", bound="PageTrajectoryEvent")
+
+
+class PageTrajectoryEvent(BaseModel):
+    """
+    Attributes:
+        items (list[TrajectoryEvent]):
+        total (int):
+        page (int):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    items: list[TrajectoryEvent]
+    total: int
+    page: int
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.trajectory_event import TrajectoryEvent
+
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        total = self.total
+
+        page = self.page
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "items": items,
+                "total": total,
+                "page": page,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.trajectory_event import TrajectoryEvent
+
+        d = dict(src_dict)
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = TrajectoryEvent.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        total = d.pop("total")
+
+        page = d.pop("page")
+
+        page_trajectory_event = cls(
+            items=items,
+            total=total,
+            page=page,
+        )
+
+        page_trajectory_event.additional_properties = d
+        return page_trajectory_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/quota_status.py
+++ b/packages/sdk/src/agent_platform/models/quota_status.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from ..models.quota_status_scope import QuotaStatusScope
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="QuotaStatus")
+
+
+class QuotaStatus(BaseModel):
+    """Quota status.
+
+    Attributes:
+        scope (QuotaStatusScope):
+        limit (int):
+        active (int):
+        available (int):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    scope: QuotaStatusScope
+    limit: int
+    active: int
+    available: int
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        scope = self.scope.value
+
+        limit = self.limit
+
+        active = self.active
+
+        available = self.available
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "scope": scope,
+                "limit": limit,
+                "active": active,
+                "available": available,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        scope = QuotaStatusScope(d.pop("scope"))
+
+        limit = d.pop("limit")
+
+        active = d.pop("active")
+
+        available = d.pop("available")
+
+        quota_status = cls(
+            scope=scope,
+            limit=limit,
+            active=active,
+            available=available,
+        )
+
+        quota_status.additional_properties = d
+        return quota_status
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/quota_status_scope.py
+++ b/packages/sdk/src/agent_platform/models/quota_status_scope.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class QuotaStatusScope(str, Enum):
+    ORG = "org"
+    USER = "user"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/sdk/src/agent_platform/models/session.py
+++ b/packages/sdk/src/agent_platform/models/session.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+from uuid import UUID
+
+from dateutil.parser import isoparse
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.session_request import SessionRequest
+    from ..models.session_status import SessionStatus
+
+
+T = TypeVar("T", bound="Session")
+
+
+class Session(BaseModel):
+    """Full session envelope: original request + live status.
+
+    Attributes:
+        id (UUID):
+        request (SessionRequest): ``POST /api/v2/sessions`` body.
+        status (SessionStatus): ``GET /api/v2/sessions/{id}/status`` response.
+        created_at (datetime.datetime):
+        started_at (datetime.datetime | None | Unset):
+        finished_at (datetime.datetime | None | Unset):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    id: UUID
+    request: SessionRequest
+    status: SessionStatus
+    created_at: datetime.datetime
+    started_at: datetime.datetime | None | Unset = UNSET
+    finished_at: datetime.datetime | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.session_request import SessionRequest
+        from ..models.session_status import SessionStatus
+
+        id = str(self.id)
+
+        request = self.request.to_dict()
+
+        status = self.status.to_dict()
+
+        created_at = self.created_at.isoformat()
+
+        started_at: None | str | Unset
+        if isinstance(self.started_at, Unset):
+            started_at = UNSET
+        elif isinstance(self.started_at, datetime.datetime):
+            started_at = self.started_at.isoformat()
+        else:
+            started_at = self.started_at
+
+        finished_at: None | str | Unset
+        if isinstance(self.finished_at, Unset):
+            finished_at = UNSET
+        elif isinstance(self.finished_at, datetime.datetime):
+            finished_at = self.finished_at.isoformat()
+        else:
+            finished_at = self.finished_at
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "id": id,
+                "request": request,
+                "status": status,
+                "created_at": created_at,
+            }
+        )
+        if started_at is not UNSET:
+            field_dict["started_at"] = started_at
+        if finished_at is not UNSET:
+            field_dict["finished_at"] = finished_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.session_request import SessionRequest
+        from ..models.session_status import SessionStatus
+
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        request = SessionRequest.from_dict(d.pop("request"))
+
+        status = SessionStatus.from_dict(d.pop("status"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        def _parse_started_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                started_at_type_0 = isoparse(data)
+
+                return started_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        started_at = _parse_started_at(d.pop("started_at", UNSET))
+
+        def _parse_finished_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                finished_at_type_0 = isoparse(data)
+
+                return finished_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        finished_at = _parse_finished_at(d.pop("finished_at", UNSET))
+
+        session = cls(
+            id=id,
+            request=request,
+            status=status,
+            created_at=created_at,
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+
+        return session

--- a/packages/sdk/src/agent_platform/models/session_request.py
+++ b/packages/sdk/src/agent_platform/models/session_request.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.agent import Agent
+    from ..models.user_message_event import UserMessageEvent
+
+
+T = TypeVar("T", bound="SessionRequest")
+
+
+class SessionRequest(BaseModel):
+    """``POST /api/v2/sessions`` body.
+
+    Attributes:
+        agent (Agent | str): Catalog id or inline Agent. Carries its own environments.
+        messages (list[UserMessageEvent] | None | str | Unset | UserMessageEvent): Queued before turn 1. Accepts a
+            string, a single UserMessageEvent, or a list.
+        max_steps (int | None | Unset): Cap on policy calls; runtime default if null.
+        max_time_s (float | None | Unset): Cap on wall-clock seconds.
+        idle_timeout_s (int | None | Unset): Idle window before auto-termination; null terminates on Answer.
+        group_id (None | str | Unset): Group id for cascading and listing.
+        parent_session_id (None | str | Unset): Parent session id.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    agent: Agent | str
+    messages: list[UserMessageEvent] | None | str | Unset | UserMessageEvent = UNSET
+    max_steps: int | None | Unset = UNSET
+    max_time_s: float | None | Unset = UNSET
+    idle_timeout_s: int | None | Unset = UNSET
+    group_id: None | str | Unset = UNSET
+    parent_session_id: None | str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.agent import Agent
+        from ..models.user_message_event import UserMessageEvent
+
+        agent: dict[str, Any] | str
+        if isinstance(self.agent, Agent):
+            agent = self.agent.to_dict()
+        else:
+            agent = self.agent
+
+        messages: dict[str, Any] | list[dict[str, Any]] | None | str | Unset
+        if isinstance(self.messages, Unset):
+            messages = UNSET
+        elif isinstance(self.messages, UserMessageEvent):
+            messages = self.messages.to_dict()
+        elif isinstance(self.messages, list):
+            messages = []
+            for messages_type_2_item_data in self.messages:
+                messages_type_2_item = messages_type_2_item_data.to_dict()
+                messages.append(messages_type_2_item)
+
+        else:
+            messages = self.messages
+
+        max_steps: int | None | Unset
+        if isinstance(self.max_steps, Unset):
+            max_steps = UNSET
+        else:
+            max_steps = self.max_steps
+
+        max_time_s: float | None | Unset
+        if isinstance(self.max_time_s, Unset):
+            max_time_s = UNSET
+        else:
+            max_time_s = self.max_time_s
+
+        idle_timeout_s: int | None | Unset
+        if isinstance(self.idle_timeout_s, Unset):
+            idle_timeout_s = UNSET
+        else:
+            idle_timeout_s = self.idle_timeout_s
+
+        group_id: None | str | Unset
+        if isinstance(self.group_id, Unset):
+            group_id = UNSET
+        else:
+            group_id = self.group_id
+
+        parent_session_id: None | str | Unset
+        if isinstance(self.parent_session_id, Unset):
+            parent_session_id = UNSET
+        else:
+            parent_session_id = self.parent_session_id
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "agent": agent,
+            }
+        )
+        if messages is not UNSET:
+            field_dict["messages"] = messages
+        if max_steps is not UNSET:
+            field_dict["max_steps"] = max_steps
+        if max_time_s is not UNSET:
+            field_dict["max_time_s"] = max_time_s
+        if idle_timeout_s is not UNSET:
+            field_dict["idle_timeout_s"] = idle_timeout_s
+        if group_id is not UNSET:
+            field_dict["group_id"] = group_id
+        if parent_session_id is not UNSET:
+            field_dict["parent_session_id"] = parent_session_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent import Agent
+        from ..models.user_message_event import UserMessageEvent
+
+        d = dict(src_dict)
+
+        def _parse_agent(data: object) -> Agent | str:
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                agent_type_1 = Agent.from_dict(data)
+
+                return agent_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(Agent | str, data)
+
+        agent = _parse_agent(d.pop("agent"))
+
+        def _parse_messages(data: object) -> list[UserMessageEvent] | None | str | Unset | UserMessageEvent:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                messages_type_1 = UserMessageEvent.from_dict(data)
+
+                return messages_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                messages_type_2 = []
+                _messages_type_2 = data
+                for messages_type_2_item_data in _messages_type_2:
+                    messages_type_2_item = UserMessageEvent.from_dict(messages_type_2_item_data)
+
+                    messages_type_2.append(messages_type_2_item)
+
+                return messages_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[UserMessageEvent] | None | str | Unset | UserMessageEvent, data)
+
+        messages = _parse_messages(d.pop("messages", UNSET))
+
+        def _parse_max_steps(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        max_steps = _parse_max_steps(d.pop("max_steps", UNSET))
+
+        def _parse_max_time_s(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        max_time_s = _parse_max_time_s(d.pop("max_time_s", UNSET))
+
+        def _parse_idle_timeout_s(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        idle_timeout_s = _parse_idle_timeout_s(d.pop("idle_timeout_s", UNSET))
+
+        def _parse_group_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        group_id = _parse_group_id(d.pop("group_id", UNSET))
+
+        def _parse_parent_session_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        parent_session_id = _parse_parent_session_id(d.pop("parent_session_id", UNSET))
+
+        session_request = cls(
+            agent=agent,
+            messages=messages,
+            max_steps=max_steps,
+            max_time_s=max_time_s,
+            idle_timeout_s=idle_timeout_s,
+            group_id=group_id,
+            parent_session_id=parent_session_id,
+        )
+
+        return session_request

--- a/packages/sdk/src/agent_platform/models/session_status.py
+++ b/packages/sdk/src/agent_platform/models/session_status.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from ..models.trajectory_status import TrajectoryStatus
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.model_usage import ModelUsage
+
+
+T = TypeVar("T", bound="SessionStatus")
+
+
+class SessionStatus(BaseModel):
+    """``GET /api/v2/sessions/{id}/status`` response.
+
+    Attributes:
+        status (TrajectoryStatus): State of a session/trajectory.
+
+            Lifecycle::
+
+                PENDING → RUNNING → {COMPLETED, FAILED, TIMED_OUT, INTERRUPTED}
+                   |        ↑  ↑
+                   |        |  └─────→ IDLE (interactive: agent waiting for next task)
+                   |        ↓
+                   └─────→ PAUSED
+        error (None | str | Unset):
+        steps (int | Unset):  Default: 0.
+        usage_per_model (list[ModelUsage] | Unset):
+        subagent_session_ids (list[UUID] | Unset):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    status: TrajectoryStatus
+    error: None | str | Unset = UNSET
+    steps: int | Unset = 0
+    usage_per_model: list[ModelUsage] | Unset = UNSET
+    subagent_session_ids: list[UUID] | Unset = UNSET
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.model_usage import ModelUsage
+
+        status = self.status.value
+
+        error: None | str | Unset
+        if isinstance(self.error, Unset):
+            error = UNSET
+        else:
+            error = self.error
+
+        steps = self.steps
+
+        usage_per_model: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.usage_per_model, Unset):
+            usage_per_model = []
+            for usage_per_model_item_data in self.usage_per_model:
+                usage_per_model_item = usage_per_model_item_data.to_dict()
+                usage_per_model.append(usage_per_model_item)
+
+        subagent_session_ids: list[str] | Unset = UNSET
+        if not isinstance(self.subagent_session_ids, Unset):
+            subagent_session_ids = []
+            for subagent_session_ids_item_data in self.subagent_session_ids:
+                subagent_session_ids_item = str(subagent_session_ids_item_data)
+                subagent_session_ids.append(subagent_session_ids_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "status": status,
+            }
+        )
+        if error is not UNSET:
+            field_dict["error"] = error
+        if steps is not UNSET:
+            field_dict["steps"] = steps
+        if usage_per_model is not UNSET:
+            field_dict["usage_per_model"] = usage_per_model
+        if subagent_session_ids is not UNSET:
+            field_dict["subagent_session_ids"] = subagent_session_ids
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.model_usage import ModelUsage
+
+        d = dict(src_dict)
+        status = TrajectoryStatus(d.pop("status"))
+
+        def _parse_error(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        error = _parse_error(d.pop("error", UNSET))
+
+        steps = d.pop("steps", UNSET)
+
+        _usage_per_model = d.pop("usage_per_model", UNSET)
+        usage_per_model: list[ModelUsage] | Unset = UNSET
+        if _usage_per_model is not UNSET:
+            usage_per_model = []
+            for usage_per_model_item_data in _usage_per_model:
+                usage_per_model_item = ModelUsage.from_dict(usage_per_model_item_data)
+
+                usage_per_model.append(usage_per_model_item)
+
+        _subagent_session_ids = d.pop("subagent_session_ids", UNSET)
+        subagent_session_ids: list[UUID] | Unset = UNSET
+        if _subagent_session_ids is not UNSET:
+            subagent_session_ids = []
+            for subagent_session_ids_item_data in _subagent_session_ids:
+                subagent_session_ids_item = UUID(subagent_session_ids_item_data)
+
+                subagent_session_ids.append(subagent_session_ids_item)
+
+        session_status = cls(
+            status=status,
+            error=error,
+            steps=steps,
+            usage_per_model=usage_per_model,
+            subagent_session_ids=subagent_session_ids,
+        )
+
+        session_status.additional_properties = d
+        return session_status
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/session_summary.py
+++ b/packages/sdk/src/agent_platform/models/session_summary.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+from uuid import UUID
+
+from dateutil.parser import isoparse
+from pydantic import BaseModel, ConfigDict
+
+from ..models.trajectory_status import TrajectoryStatus
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.user_message_event import UserMessageEvent
+
+
+T = TypeVar("T", bound="SessionSummary")
+
+
+class SessionSummary(BaseModel):
+    """Flat projection for session listings.
+
+    Attributes:
+        id (UUID):
+        status (TrajectoryStatus): State of a session/trajectory.
+
+            Lifecycle::
+
+                PENDING → RUNNING → {COMPLETED, FAILED, TIMED_OUT, INTERRUPTED}
+                   |        ↑  ↑
+                   |        |  └─────→ IDLE (interactive: agent waiting for next task)
+                   |        ↓
+                   └─────→ PAUSED
+        created_at (datetime.datetime):
+        first_message (None | Unset | UserMessageEvent):
+        started_at (datetime.datetime | None | Unset):
+        finished_at (datetime.datetime | None | Unset):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    id: UUID
+    status: TrajectoryStatus
+    created_at: datetime.datetime
+    first_message: None | Unset | UserMessageEvent = UNSET
+    started_at: datetime.datetime | None | Unset = UNSET
+    finished_at: datetime.datetime | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.user_message_event import UserMessageEvent
+
+        id = str(self.id)
+
+        status = self.status.value
+
+        created_at = self.created_at.isoformat()
+
+        first_message: dict[str, Any] | None | Unset
+        if isinstance(self.first_message, Unset):
+            first_message = UNSET
+        elif isinstance(self.first_message, UserMessageEvent):
+            first_message = self.first_message.to_dict()
+        else:
+            first_message = self.first_message
+
+        started_at: None | str | Unset
+        if isinstance(self.started_at, Unset):
+            started_at = UNSET
+        elif isinstance(self.started_at, datetime.datetime):
+            started_at = self.started_at.isoformat()
+        else:
+            started_at = self.started_at
+
+        finished_at: None | str | Unset
+        if isinstance(self.finished_at, Unset):
+            finished_at = UNSET
+        elif isinstance(self.finished_at, datetime.datetime):
+            finished_at = self.finished_at.isoformat()
+        else:
+            finished_at = self.finished_at
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "id": id,
+                "status": status,
+                "created_at": created_at,
+            }
+        )
+        if first_message is not UNSET:
+            field_dict["first_message"] = first_message
+        if started_at is not UNSET:
+            field_dict["started_at"] = started_at
+        if finished_at is not UNSET:
+            field_dict["finished_at"] = finished_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.user_message_event import UserMessageEvent
+
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        status = TrajectoryStatus(d.pop("status"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        def _parse_first_message(data: object) -> None | Unset | UserMessageEvent:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                first_message_type_0 = UserMessageEvent.from_dict(data)
+
+                return first_message_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UserMessageEvent, data)
+
+        first_message = _parse_first_message(d.pop("first_message", UNSET))
+
+        def _parse_started_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                started_at_type_0 = isoparse(data)
+
+                return started_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        started_at = _parse_started_at(d.pop("started_at", UNSET))
+
+        def _parse_finished_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                finished_at_type_0 = isoparse(data)
+
+                return finished_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        finished_at = _parse_finished_at(d.pop("finished_at", UNSET))
+
+        session_summary = cls(
+            id=id,
+            status=status,
+            created_at=created_at,
+            first_message=first_message,
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+
+        return session_summary

--- a/packages/sdk/src/agent_platform/models/share_link.py
+++ b/packages/sdk/src/agent_platform/models/share_link.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ShareLink")
+
+
+class ShareLink(BaseModel):
+    """Public share URL for a session.
+
+    ``share_url`` is a path; clients prepend the AgP host. Today this points at the
+    v1 share router (``/share/api/v1/trajectories/{id}``); will migrate to
+    ``/share/v1/sessions/{id}`` once the v2 share router lands.
+
+        Attributes:
+            share_url (str):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    share_url: str
+
+    def to_dict(self) -> dict[str, Any]:
+        share_url = self.share_url
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "share_url": share_url,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        share_url = d.pop("share_url")
+
+        share_link = cls(
+            share_url=share_url,
+        )
+
+        return share_link

--- a/packages/sdk/src/agent_platform/models/skill.py
+++ b/packages/sdk/src/agent_platform/models/skill.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Skill")
+
+
+class Skill(BaseModel):
+    """Named instruction content. Loaded by name via ``load_skill`` or rendered inline by toolboxes.
+
+    Attributes:
+        name (str): Catalog id. Format: lowercase ASCII letters, digits and hyphens; must start and end with
+            alphanumeric; max 63 chars per segment; optional single 'org/' namespace prefix (e.g. 'h/web-environment').
+        description (str): One-line routing hint.
+        body (str): Markdown content.
+        source (None | str | Unset): Provenance URL.
+        url_pattern (None | str | Unset): Informational regex hinting at URLs where this skill applies (not gated).
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    name: str
+    description: str
+    body: str
+    source: None | str | Unset = UNSET
+    url_pattern: None | str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        description = self.description
+
+        body = self.body
+
+        source: None | str | Unset
+        if isinstance(self.source, Unset):
+            source = UNSET
+        else:
+            source = self.source
+
+        url_pattern: None | str | Unset
+        if isinstance(self.url_pattern, Unset):
+            url_pattern = UNSET
+        else:
+            url_pattern = self.url_pattern
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "name": name,
+                "description": description,
+                "body": body,
+            }
+        )
+        if source is not UNSET:
+            field_dict["source"] = source
+        if url_pattern is not UNSET:
+            field_dict["url_pattern"] = url_pattern
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        description = d.pop("description")
+
+        body = d.pop("body")
+
+        def _parse_source(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        source = _parse_source(d.pop("source", UNSET))
+
+        def _parse_url_pattern(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        url_pattern = _parse_url_pattern(d.pop("url_pattern", UNSET))
+
+        skill = cls(
+            name=name,
+            description=description,
+            body=body,
+            source=source,
+            url_pattern=url_pattern,
+        )
+
+        return skill

--- a/packages/sdk/src/agent_platform/models/skill_record.py
+++ b/packages/sdk/src/agent_platform/models/skill_record.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+from uuid import UUID
+
+from dateutil.parser import isoparse
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="SkillRecord")
+
+
+class SkillRecord(BaseModel):
+    """Named prompt fragment loaded into an agent's system prompt.
+
+    Attributes:
+        id (UUID):
+        name (str):
+        description (str):
+        body (str):
+        source (None | str):
+        url_pattern (None | str):
+        uri (None | str):
+        reserved (bool):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    id: UUID
+    name: str
+    description: str
+    body: str
+    source: None | str
+    url_pattern: None | str
+    uri: None | str
+    reserved: bool
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        name = self.name
+
+        description = self.description
+
+        body = self.body
+
+        source: None | str
+        source = self.source
+
+        url_pattern: None | str
+        url_pattern = self.url_pattern
+
+        uri: None | str
+        uri = self.uri
+
+        reserved = self.reserved
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "name": name,
+                "description": description,
+                "body": body,
+                "source": source,
+                "url_pattern": url_pattern,
+                "uri": uri,
+                "reserved": reserved,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        name = d.pop("name")
+
+        description = d.pop("description")
+
+        body = d.pop("body")
+
+        def _parse_source(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        source = _parse_source(d.pop("source"))
+
+        def _parse_url_pattern(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        url_pattern = _parse_url_pattern(d.pop("url_pattern"))
+
+        def _parse_uri(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        uri = _parse_uri(d.pop("uri"))
+
+        reserved = d.pop("reserved")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        skill_record = cls(
+            id=id,
+            name=name,
+            description=description,
+            body=body,
+            source=source,
+            url_pattern=url_pattern,
+            uri=uri,
+            reserved=reserved,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        skill_record.additional_properties = d
+        return skill_record
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/trajectory_changes.py
+++ b/packages/sdk/src/agent_platform/models/trajectory_changes.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from dateutil.parser import isoparse
+from pydantic import BaseModel, ConfigDict
+
+from ..models.trajectory_status import TrajectoryStatus
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.metrics import Metrics
+    from ..models.trajectory_changes_answer_type_1 import TrajectoryChangesAnswerType1
+    from ..models.trajectory_event import TrajectoryEvent
+
+
+T = TypeVar("T", bound="TrajectoryChanges")
+
+
+class TrajectoryChanges(BaseModel):
+    """Changes to a trajectory.
+
+    This represents a batch of updates returned by the polling API
+    when checking for new events and status changes on a trajectory.
+
+    Used to incrementally fetch new events without
+    re-downloading the entire trajectory history.
+
+    Attributes:
+        status: Current status of the trajectory
+        started_at: When the trajectory started execution (None if not yet started)
+        finished_at: When the trajectory finished (None if still running)
+        error: Error message if trajectory failed (None if no error)
+        new_events: List of new events since the last poll (empty if no new events)
+        answer: Answer to the trajectory (None if not available)
+
+        Attributes:
+            status (TrajectoryStatus): State of a session/trajectory.
+
+                Lifecycle::
+
+                    PENDING → RUNNING → {COMPLETED, FAILED, TIMED_OUT, INTERRUPTED}
+                       |        ↑  ↑
+                       |        |  └─────→ IDLE (interactive: agent waiting for next task)
+                       |        ↓
+                       └─────→ PAUSED
+            started_at (datetime.datetime | None | Unset):
+            finished_at (datetime.datetime | None | Unset):
+            error (None | str | Unset):
+            new_events (list[TrajectoryEvent] | Unset):
+            answer (None | str | TrajectoryChangesAnswerType1 | Unset):
+            metrics (Metrics | Unset): Metrics for a trajectory.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    status: TrajectoryStatus
+    started_at: datetime.datetime | None | Unset = UNSET
+    finished_at: datetime.datetime | None | Unset = UNSET
+    error: None | str | Unset = UNSET
+    new_events: list[TrajectoryEvent] | Unset = UNSET
+    answer: None | str | TrajectoryChangesAnswerType1 | Unset = UNSET
+    metrics: Metrics | Unset = UNSET
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.metrics import Metrics
+        from ..models.trajectory_changes_answer_type_1 import TrajectoryChangesAnswerType1
+        from ..models.trajectory_event import TrajectoryEvent
+
+        status = self.status.value
+
+        started_at: None | str | Unset
+        if isinstance(self.started_at, Unset):
+            started_at = UNSET
+        elif isinstance(self.started_at, datetime.datetime):
+            started_at = self.started_at.isoformat()
+        else:
+            started_at = self.started_at
+
+        finished_at: None | str | Unset
+        if isinstance(self.finished_at, Unset):
+            finished_at = UNSET
+        elif isinstance(self.finished_at, datetime.datetime):
+            finished_at = self.finished_at.isoformat()
+        else:
+            finished_at = self.finished_at
+
+        error: None | str | Unset
+        if isinstance(self.error, Unset):
+            error = UNSET
+        else:
+            error = self.error
+
+        new_events: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.new_events, Unset):
+            new_events = []
+            for new_events_item_data in self.new_events:
+                new_events_item = new_events_item_data.to_dict()
+                new_events.append(new_events_item)
+
+        answer: dict[str, Any] | None | str | Unset
+        if isinstance(self.answer, Unset):
+            answer = UNSET
+        elif isinstance(self.answer, TrajectoryChangesAnswerType1):
+            answer = self.answer.to_dict()
+        else:
+            answer = self.answer
+
+        metrics: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.metrics, Unset):
+            metrics = self.metrics.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "status": status,
+            }
+        )
+        if started_at is not UNSET:
+            field_dict["started_at"] = started_at
+        if finished_at is not UNSET:
+            field_dict["finished_at"] = finished_at
+        if error is not UNSET:
+            field_dict["error"] = error
+        if new_events is not UNSET:
+            field_dict["new_events"] = new_events
+        if answer is not UNSET:
+            field_dict["answer"] = answer
+        if metrics is not UNSET:
+            field_dict["metrics"] = metrics
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.metrics import Metrics
+        from ..models.trajectory_changes_answer_type_1 import TrajectoryChangesAnswerType1
+        from ..models.trajectory_event import TrajectoryEvent
+
+        d = dict(src_dict)
+        status = TrajectoryStatus(d.pop("status"))
+
+        def _parse_started_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                started_at_type_0 = isoparse(data)
+
+                return started_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        started_at = _parse_started_at(d.pop("started_at", UNSET))
+
+        def _parse_finished_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                finished_at_type_0 = isoparse(data)
+
+                return finished_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        finished_at = _parse_finished_at(d.pop("finished_at", UNSET))
+
+        def _parse_error(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        error = _parse_error(d.pop("error", UNSET))
+
+        _new_events = d.pop("new_events", UNSET)
+        new_events: list[TrajectoryEvent] | Unset = UNSET
+        if _new_events is not UNSET:
+            new_events = []
+            for new_events_item_data in _new_events:
+                new_events_item = TrajectoryEvent.from_dict(new_events_item_data)
+
+                new_events.append(new_events_item)
+
+        def _parse_answer(data: object) -> None | str | TrajectoryChangesAnswerType1 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                answer_type_1 = TrajectoryChangesAnswerType1.from_dict(data)
+
+                return answer_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | str | TrajectoryChangesAnswerType1 | Unset, data)
+
+        answer = _parse_answer(d.pop("answer", UNSET))
+
+        _metrics = d.pop("metrics", UNSET)
+        metrics: Metrics | Unset
+        if isinstance(_metrics, Unset):
+            metrics = UNSET
+        else:
+            metrics = Metrics.from_dict(_metrics)
+
+        trajectory_changes = cls(
+            status=status,
+            started_at=started_at,
+            finished_at=finished_at,
+            error=error,
+            new_events=new_events,
+            answer=answer,
+            metrics=metrics,
+        )
+
+        trajectory_changes.additional_properties = d
+        return trajectory_changes
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/trajectory_changes_answer_type_1.py
+++ b/packages/sdk/src/agent_platform/models/trajectory_changes_answer_type_1.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TrajectoryChangesAnswerType1")
+
+
+class TrajectoryChangesAnswerType1(BaseModel):
+    """ """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        trajectory_changes_answer_type_1 = cls()
+
+        trajectory_changes_answer_type_1.additional_properties = d
+        return trajectory_changes_answer_type_1
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/trajectory_event.py
+++ b/packages/sdk/src/agent_platform/models/trajectory_event.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from dateutil.parser import isoparse
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TrajectoryEvent")
+
+
+class TrajectoryEvent(BaseModel):
+    """Event from a trajectory.
+
+    Unified from agp_client and agent_platform.
+    Uses the richer agent_platform version with screenshot serialization.
+
+    Events represent individual actions, observations, or state changes during
+    trajectory execution. They form a chronological log of everything that happened.
+
+    Common event types:
+    - AgentStartedEvent: Agent begins execution
+    - AgentCompletionEvent: Agent finishes successfully
+    - AgentErrorEvent: Agent encounters an error
+    - AgentEvent: Generic wrapper for agent-emitted events (policy_event, tool_result, observation_event)
+    - LiveViewUrlEvent: Live view URL becomes available
+    - ChatMessageEvent: Agent sends a chat message
+
+    Attributes:
+        type: The type/name of the event (e.g., "AgentStartedEvent", "AgentEvent")
+        data: Event-specific data payload (structure varies by event type)
+        timestamp: When the event occurred
+
+        Attributes:
+            type_ (str):
+            data (Any):
+            timestamp (datetime.datetime):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    type_: str
+    data: Any
+    timestamp: datetime.datetime
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        data = self.data
+
+        timestamp = self.timestamp.isoformat()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "type": type_,
+                "data": data,
+                "timestamp": timestamp,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = d.pop("type")
+
+        data = d.pop("data")
+
+        timestamp = isoparse(d.pop("timestamp"))
+
+        trajectory_event = cls(
+            type_=type_,
+            data=data,
+            timestamp=timestamp,
+        )
+
+        trajectory_event.additional_properties = d
+        return trajectory_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/trajectory_status.py
+++ b/packages/sdk/src/agent_platform/models/trajectory_status.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class TrajectoryStatus(str, Enum):
+    COMPLETED = "completed"
+    FAILED = "failed"
+    IDLE = "idle"
+    INTERRUPTED = "interrupted"
+    PAUSED = "paused"
+    PENDING = "pending"
+    RUNNING = "running"
+    TIMED_OUT = "timed_out"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/sdk/src/agent_platform/models/update_agent.py
+++ b/packages/sdk/src/agent_platform/models/update_agent.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.agent import Agent
+
+
+T = TypeVar("T", bound="UpdateAgent")
+
+
+class UpdateAgent(BaseModel):
+    """``PUT /api/v2/agents/{agent_identifier}`` body. Full replace; ``spec.name`` is immutable.
+
+    Attributes:
+        spec (Agent): Declarative agent definition.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    spec: Agent
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.agent import Agent
+
+        spec = self.spec.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "spec": spec,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent import Agent
+
+        d = dict(src_dict)
+        spec = Agent.from_dict(d.pop("spec"))
+
+        update_agent = cls(
+            spec=spec,
+        )
+
+        return update_agent

--- a/packages/sdk/src/agent_platform/models/update_environment.py
+++ b/packages/sdk/src/agent_platform/models/update_environment.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.browser import Browser
+    from ..models.code_sandbox import CodeSandbox
+    from ..models.mcp import MCP
+    from ..models.memory import Memory
+
+
+T = TypeVar("T", bound="UpdateEnvironment")
+
+
+class UpdateEnvironment(BaseModel):
+    """``PUT /api/v2/environments/{env_identifier}`` body. Full replace; ``spec.id`` is immutable.
+
+    Attributes:
+        spec (Browser | CodeSandbox | MCP | Memory):
+        description (str | Unset):  Default: ''.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    spec: Browser | CodeSandbox | MCP | Memory
+    description: str | Unset = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.browser import Browser
+        from ..models.code_sandbox import CodeSandbox
+        from ..models.mcp import MCP
+        from ..models.memory import Memory
+
+        spec: dict[str, Any]
+        if isinstance(self.spec, Browser):
+            spec = self.spec.to_dict()
+        elif isinstance(self.spec, CodeSandbox):
+            spec = self.spec.to_dict()
+        elif isinstance(self.spec, MCP):
+            spec = self.spec.to_dict()
+        else:
+            spec = self.spec.to_dict()
+
+        description = self.description
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "spec": spec,
+            }
+        )
+        if description is not UNSET:
+            field_dict["description"] = description
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.browser import Browser
+        from ..models.code_sandbox import CodeSandbox
+        from ..models.mcp import MCP
+        from ..models.memory import Memory
+
+        d = dict(src_dict)
+
+        def _parse_spec(data: object) -> Browser | CodeSandbox | MCP | Memory:
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                spec_type_0 = Browser.from_dict(data)
+
+                return spec_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                spec_type_1 = CodeSandbox.from_dict(data)
+
+                return spec_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                spec_type_2 = MCP.from_dict(data)
+
+                return spec_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            if not isinstance(data, dict):
+                raise TypeError()
+            spec_type_3 = Memory.from_dict(data)
+
+            return spec_type_3
+
+        spec = _parse_spec(d.pop("spec"))
+
+        description = d.pop("description", UNSET)
+
+        update_environment = cls(
+            spec=spec,
+            description=description,
+        )
+
+        return update_environment

--- a/packages/sdk/src/agent_platform/models/update_memory.py
+++ b/packages/sdk/src/agent_platform/models/update_memory.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="UpdateMemory")
+
+
+class UpdateMemory(BaseModel):
+    """Update a memory's value in place.
+
+    Attributes:
+        value (str):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    value: str
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        value = self.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "value": value,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        value = d.pop("value")
+
+        update_memory = cls(
+            value=value,
+        )
+
+        update_memory.additional_properties = d
+        return update_memory
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/update_skill.py
+++ b/packages/sdk/src/agent_platform/models/update_skill.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="UpdateSkill")
+
+
+class UpdateSkill(BaseModel):
+    """Request to update a skill. Full replacement; `name` is immutable.
+
+    Attributes:
+        description (str):
+        body (str | Unset):  Default: ''.
+        source (None | str | Unset):
+        url_pattern (None | str | Unset):
+        uri (None | str | Unset):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    description: str
+    body: str | Unset = ""
+    source: None | str | Unset = UNSET
+    url_pattern: None | str | Unset = UNSET
+    uri: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        description = self.description
+
+        body = self.body
+
+        source: None | str | Unset
+        if isinstance(self.source, Unset):
+            source = UNSET
+        else:
+            source = self.source
+
+        url_pattern: None | str | Unset
+        if isinstance(self.url_pattern, Unset):
+            url_pattern = UNSET
+        else:
+            url_pattern = self.url_pattern
+
+        uri: None | str | Unset
+        if isinstance(self.uri, Unset):
+            uri = UNSET
+        else:
+            uri = self.uri
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "description": description,
+            }
+        )
+        if body is not UNSET:
+            field_dict["body"] = body
+        if source is not UNSET:
+            field_dict["source"] = source
+        if url_pattern is not UNSET:
+            field_dict["url_pattern"] = url_pattern
+        if uri is not UNSET:
+            field_dict["uri"] = uri
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        description = d.pop("description")
+
+        body = d.pop("body", UNSET)
+
+        def _parse_source(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        source = _parse_source(d.pop("source", UNSET))
+
+        def _parse_url_pattern(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        url_pattern = _parse_url_pattern(d.pop("url_pattern", UNSET))
+
+        def _parse_uri(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        uri = _parse_uri(d.pop("uri", UNSET))
+
+        update_skill = cls(
+            description=description,
+            body=body,
+            source=source,
+            url_pattern=url_pattern,
+            uri=uri,
+        )
+
+        update_skill.additional_properties = d
+        return update_skill
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/user_message_batch.py
+++ b/packages/sdk/src/agent_platform/models/user_message_batch.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, Literal, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.user_message_event import UserMessageEvent
+
+
+T = TypeVar("T", bound="UserMessageBatch")
+
+
+class UserMessageBatch(BaseModel):
+    """Batch of user messages.
+
+    Attributes:
+        messages (list[UserMessageEvent]):
+        type_ (Literal['batch'] | Unset):  Default: 'batch'.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    messages: list[UserMessageEvent]
+    type_: Literal["batch"] | Unset = "batch"
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.user_message_event import UserMessageEvent
+
+        messages = []
+        for messages_item_data in self.messages:
+            messages_item = messages_item_data.to_dict()
+            messages.append(messages_item)
+
+        type_ = self.type_
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "messages": messages,
+            }
+        )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.user_message_event import UserMessageEvent
+
+        d = dict(src_dict)
+        messages = []
+        _messages = d.pop("messages")
+        for messages_item_data in _messages:
+            messages_item = UserMessageEvent.from_dict(messages_item_data)
+
+            messages.append(messages_item)
+
+        type_ = cast(Literal["batch"] | Unset, d.pop("type", UNSET))
+        if type_ != "batch" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'batch', got '{type_}'")
+
+        user_message_batch = cls(
+            messages=messages,
+            type_=type_,
+        )
+
+        return user_message_batch

--- a/packages/sdk/src/agent_platform/models/user_message_event.py
+++ b/packages/sdk/src/agent_platform/models/user_message_event.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, Literal, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="UserMessageEvent")
+
+
+class UserMessageEvent(BaseModel):
+    """The user is sending a message to an active agent.
+
+    Attributes:
+        message (str):
+        type_ (Literal['user_message'] | Unset):  Default: 'user_message'.
+        images (list[str] | Unset):
+        caller_id (str | Unset):  Default: 'user'.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    message: str
+    type_: Literal["user_message"] | Unset = "user_message"
+    images: list[str] | Unset = UNSET
+    caller_id: str | Unset = "user"
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        message = self.message
+
+        type_ = self.type_
+
+        images: list[str] | Unset = UNSET
+        if not isinstance(self.images, Unset):
+            images = self.images
+
+        caller_id = self.caller_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "message": message,
+            }
+        )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+        if images is not UNSET:
+            field_dict["images"] = images
+        if caller_id is not UNSET:
+            field_dict["caller_id"] = caller_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        message = d.pop("message")
+
+        type_ = cast(Literal["user_message"] | Unset, d.pop("type", UNSET))
+        if type_ != "user_message" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'user_message', got '{type_}'")
+
+        images = cast(list[str], d.pop("images", UNSET))
+
+        caller_id = d.pop("caller_id", UNSET)
+
+        user_message_event = cls(
+            message=message,
+            type_=type_,
+            images=images,
+            caller_id=caller_id,
+        )
+
+        user_message_event.additional_properties = d
+        return user_message_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/validation_error.py
+++ b/packages/sdk/src/agent_platform/models/validation_error.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.validation_error_context import ValidationErrorContext
+
+
+T = TypeVar("T", bound="ValidationError")
+
+
+class ValidationError(BaseModel):
+    """
+    Attributes:
+        loc (list[int | str]):
+        msg (str):
+        type_ (str):
+        input_ (Any | Unset):
+        ctx (ValidationErrorContext | Unset):
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    loc: list[int | str]
+    msg: str
+    type_: str
+    input_: Any | Unset = UNSET
+    ctx: ValidationErrorContext | Unset = UNSET
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.validation_error_context import ValidationErrorContext
+
+        loc = []
+        for loc_item_data in self.loc:
+            loc_item: int | str
+            loc_item = loc_item_data
+            loc.append(loc_item)
+
+        msg = self.msg
+
+        type_ = self.type_
+
+        input_ = self.input_
+
+        ctx: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.ctx, Unset):
+            ctx = self.ctx.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "loc": loc,
+                "msg": msg,
+                "type": type_,
+            }
+        )
+        if input_ is not UNSET:
+            field_dict["input"] = input_
+        if ctx is not UNSET:
+            field_dict["ctx"] = ctx
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.validation_error_context import ValidationErrorContext
+
+        d = dict(src_dict)
+        loc = []
+        _loc = d.pop("loc")
+        for loc_item_data in _loc:
+
+            def _parse_loc_item(data: object) -> int | str:
+                return cast(int | str, data)
+
+            loc_item = _parse_loc_item(loc_item_data)
+
+            loc.append(loc_item)
+
+        msg = d.pop("msg")
+
+        type_ = d.pop("type")
+
+        input_ = d.pop("input", UNSET)
+
+        _ctx = d.pop("ctx", UNSET)
+        ctx: ValidationErrorContext | Unset
+        if isinstance(_ctx, Unset):
+            ctx = UNSET
+        else:
+            ctx = ValidationErrorContext.from_dict(_ctx)
+
+        validation_error = cls(
+            loc=loc,
+            msg=msg,
+            type_=type_,
+            input_=input_,
+            ctx=ctx,
+        )
+
+        validation_error.additional_properties = d
+        return validation_error
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/models/validation_error_context.py
+++ b/packages/sdk/src/agent_platform/models/validation_error_context.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, BinaryIO, Generator, TextIO, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ValidationErrorContext")
+
+
+class ValidationErrorContext(BaseModel):
+    """ """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
+    additional_properties: dict[str, Any] = {}
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        validation_error_context = cls()
+
+        validation_error_context.additional_properties = d
+        return validation_error_context
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/sdk/src/agent_platform/py.typed
+++ b/packages/sdk/src/agent_platform/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/packages/sdk/src/agent_platform/types.py
+++ b/packages/sdk/src/agent_platform/types.py
@@ -1,0 +1,54 @@
+"""Contains some shared types for properties"""
+
+from collections.abc import Mapping, MutableMapping
+from http import HTTPStatus
+from typing import IO, BinaryIO, Generic, Literal, TypeVar
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+# The types that `httpx.Client(files=)` can accept, copied from that library.
+FileContent = IO[bytes] | bytes | str
+FileTypes = (
+    # (filename, file (or bytes), content_type)
+    tuple[str | None, FileContent, str | None]
+    # (filename, file (or bytes), content_type, headers)
+    | tuple[str | None, FileContent, str | None, Mapping[str, str]]
+)
+RequestFiles = list[tuple[str, FileTypes]]
+
+
+@define
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: str | None = None
+    mime_type: str | None = None
+
+    def to_tuple(self) -> FileTypes:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: T | None
+
+
+__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]


### PR DESCRIPTION
First automated SDK sync. Seeds `packages/sdk/src/agent_platform/` from the agent_platform public v2 OpenAPI schema and sets the SDK version to `0.1.0`.

**Upstream:** [agent_platform@3b0d87c](https://github.com/hcompai/agent_platform/commit/3b0d87c3722c062c380b6b3f6a213a6d7e75d64e)
**Version:** `0.1.0` (minor, additive)

Generated by `regen-on-dispatch.yaml` (manually triggered for this first run; the branch + regen were produced by the workflow, only the PR open step was blocked by org policy on Actions creating PRs — fix incoming in a separate PR).

## Reviewer checklist
- [ ] `packages/sdk/src/` matches the public v2 surface (sessions/agents/environments/skills/memories)
- [ ] Version `0.1.0` is correct for the first publishable cut
- [ ] CI green

Made with [Cursor](https://cursor.com)