### PR TITLE
docs: hermetic public surface (strip internal codegen references)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# Default code owners for every file. Pull requests auto-request review from
-# both unless explicitly overridden by a more specific pattern below.
 * @abonneth @adeprezh

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,5 @@
 version: 2
 
-# Keep agent_platform pinning to date by also bumping the third-party deps
-# that ship with the generated SDK (httpx, pydantic, attrs, ...) plus dev
-# tooling. The SDK code itself is regenerated automatically on every upstream
-# schema change, so dependabot only covers what we hand-pin in pyproject.toml.
-
 updates:
   - package-ecosystem: pip
     directory: "/"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,9 +1,5 @@
 name: CodeQL
 
-# Static analysis for the hand-maintained parts of this repo (tests, packaging,
-# workflows). The generated SDK under packages/sdk/src/ is excluded — findings there
-# can only be fixed in the upstream agent_platform code generator.
-
 on:
   push:
     branches: [main]

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-# packages/sdk/src/agent_platform/ is generated but committed: the automated sync PR
-# from agent_platform commits the regenerated src/ so reviewers can see what changed.
-
-.openapi-generator-ignore
-.openapi-generator/
 __pycache__/
 *.pyc
 .pytest_cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,8 @@
 # Contributing
 
-This repository is an **output-only mirror**. The Python SDK under
-`packages/sdk/src/agent_platform/` is generated from
-[hcompai/agent_platform](https://github.com/hcompai/agent_platform)'s OpenAPI
-schema and synced here by an automated PR. The codegen toolchain (generator,
-templates, config, version policy) lives upstream in `agent_platform`.
-
-**Do not hand-edit anything under `packages/sdk/src/`.** The next sync PR will
-overwrite it. To change the SDK:
-
-| You want to change... | Where to make the change |
-| --- | --- |
-| A model field, an endpoint, or which endpoints the SDK exposes | The API in [`hcompai/agent_platform`](https://github.com/hcompai/agent_platform) |
-| The generator config, templates, or version policy | `sdk-codegen/` in [`hcompai/agent_platform`](https://github.com/hcompai/agent_platform) |
+The client code under `packages/sdk/src/` is generated and should not be
+hand-edited — changes there are overwritten when the SDK is next published. For
+SDK behavior or API coverage, open an issue describing what you need.
 
 Hand-written parts of this repo (tests, packaging, docs) are open to PRs. For
 anything non-trivial, open an issue first.
@@ -27,6 +17,6 @@ uv sync --group dev
 ## Run tests
 
 ```bash
-uv run pytest packages/sdk/tests                                 # unit (integration deselected)
-uv run pytest packages/sdk/tests/integration -m integration -v    # live API (needs HAI_API_KEY_TEST)
+uv run pytest packages/sdk/tests
+uv run pytest packages/sdk/tests/integration -m integration -v
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # hai-agents-python
 
-Python developer libraries and tools for [H Company's Agent Platform](https://hcompany.ai). The TypeScript counterpart lives in [`hai-agents-ts`](https://github.com/hcompai/hai-agents-ts).
+Python developer libraries and tools for [H Company's Agent Platform](https://hcompany.ai).
 
 ## Packages
 
@@ -12,15 +12,13 @@ Python developer libraries and tools for [H Company's Agent Platform](https://hc
 | --- | --- |
 | [`packages/sdk`](packages/sdk) | Python SDK — sync and async clients, fully typed with Pydantic v2. Published to PyPI as [`agent-platform`](https://pypi.org/project/agent-platform/). |
 
-CLI and MCP server packages will land here as additional workspace members.
-
 ## Development
 
 This repo is a [uv workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/). From the root:
 
 ```bash
-uv sync           # install every package + dev tools into one venv
+uv sync
 uv run pytest packages/sdk/tests
 ```
 
-The SDK in `packages/sdk/src/` is generated upstream in [`hcompai/agent_platform`](https://github.com/hcompai/agent_platform) and synced here by an automated PR; this repo is an output-only mirror. See [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/packages/sdk/tests/conftest.py
+++ b/packages/sdk/tests/conftest.py
@@ -1,22 +1,15 @@
-"""Shared fixtures and helpers for SDK model roundtrip tests.
+"""Shared fixtures and helpers for SDK model round-trip tests.
 
-The test strategy (per 02-RESEARCH.md Pattern 6): for each backend public_api/ model,
-construct a canonical input dict matching the OpenAPI schema, parse it through the
-SDK's generated model via from_dict() (the SDK's public parsing entrypoint), serialize
-back to dict via to_dict(), and assert the result equals the input.
+For each model, construct a canonical input dict matching the API schema, parse it
+through the SDK model's from_dict() (the public parsing entrypoint), serialize back
+via to_dict(), and assert the result equals the input. from_dict()/to_dict() is the
+SDK's actual public round-trip contract and handles the UNSET sentinel and
+discriminated-union resolution that model_validate() bypasses.
 
-DEVIATION NOTE: The plan template references model_validate() as the parsing path.
-After reading the generated code, model_validate() does NOT correctly handle the
-SDK's discriminated-union fields (spec in Environment, agent in SessionRequest)
-because Pydantic's native coercion does not know the SDK's UNSET sentinel or its
-from_dict() union-resolution logic.  We use from_dict() + to_dict() instead — this
-is the SDK's actual public roundtrip contract and is a tighter test.
-
-Datetime fields are the most common roundtrip-mismatch source — Pydantic v2 emits
-ISO 8601 with `+00:00` offset, python-dateutil's isoparse (used in the generated
-from_dict() methods) re-emits via .isoformat() which also uses `+00:00`.  Both
-sides therefore agree on the `+00:00` form.  We still normalize in assert_json_equal()
-to guard against future format drift.
+Datetime fields are the most common mismatch source: Pydantic v2 emits ISO 8601 with
+a `+00:00` offset, and python-dateutil's isoparse (used in from_dict()) re-emits the
+same form via .isoformat(). assert_json_equal() still normalizes to guard against
+future format drift.
 """
 
 from __future__ import annotations

--- a/packages/sdk/tests/test_model_compat.py
+++ b/packages/sdk/tests/test_model_compat.py
@@ -1,21 +1,10 @@
-"""SDK-05 verification: SDK Pydantic v2 models round-trip JSON byte-identically.
+"""SDK Pydantic v2 models round-trip JSON byte-identically.
 
-Each test parses a canonical payload through the SDK model's from_dict() method
-(the SDK's public parsing entrypoint) and asserts the serialized output from
-to_dict() matches the input (after documented normalization for ISO 8601 datetime
-format).
-
-DEVIATION from plan template:
-  The plan suggested model_validate() for parsing.  After reading the generated code,
-  model_validate() does not correctly handle the SDK's discriminated-union fields
-  (e.g., spec in Environment, agent in SessionRequest) because Pydantic's native
-  coercion bypasses the SDK's UNSET sentinel and union-resolution logic in from_dict().
-  We use from_dict() + to_dict() — the SDK's actual public round-trip contract.
-  This is a tighter test: it validates the same path users call in production.
-
-If any test fails, the SDK model and the OpenAPI schema have drifted.  Either:
-  (a) the schema changed — run make regen-schema and regenerate the SDK, or
-  (b) the model.py.jinja template is buggy — fix template and regenerate.
+Each test parses a canonical payload through the model's from_dict() (the SDK's
+public parsing entrypoint) and asserts to_dict() reproduces the input (after the
+documented ISO 8601 datetime normalization). from_dict()/to_dict() is the actual
+public round-trip contract — it exercises the same path users call, including the
+UNSET sentinel and discriminated-union resolution that model_validate() bypasses.
 """
 
 from __future__ import annotations
@@ -118,9 +107,8 @@ def test_agent_record_roundtrip(agent_record_payload: Dict[str, Any]) -> None:
 def test_no_attrs_in_generated_models() -> None:
     """Structural enforcement: no ``attrs`` imports in models/.
 
-    SDK-05 explicitly forbids ``attrs`` and ``dataclass`` in models — this test
-    fails loudly if the generation strategy regresses (e.g., template
-    misconfiguration or manual edit that introduces attrs).
+    Models must be Pydantic v2 only; ``attrs`` and ``dataclass`` are forbidden,
+    so this test fails loudly if they reappear.
 
     Note: client.py and types.py deliberately use attrs (for AuthenticatedClient
     and File/Response) — that is expected and out of scope here.  Only models/.
@@ -143,11 +131,11 @@ def test_no_attrs_in_generated_models() -> None:
             if pattern in text:
                 violations.append(f"{py_file.name}: contains forbidden pattern '{pattern}'")
 
-    assert not violations, "Generated models violate SDK-05 (no attrs/dataclass):\n" + "\n".join(violations)
+    assert not violations, "Models must not use attrs/dataclass:\n" + "\n".join(violations)
 
 
 def test_datetime_field_serializes_as_iso8601(skill_record_payload: Dict[str, Any]) -> None:
-    """Datetime fields must serialize as ISO 8601 strings (Pitfall 5 from 02-RESEARCH.md).
+    """Datetime fields must serialize as ISO 8601 strings.
 
     SkillRecord carries two required datetime fields (created_at, updated_at). We verify:
       1. The serialized value is a string (not a datetime object)
@@ -171,9 +159,8 @@ def test_model_validate_simple_fields(skill_record_payload: Dict[str, Any]) -> N
     """Verify model_validate() works for models without complex union/UNSET fields.
 
     SkillRecord has no UNSET-guarded fields (its optional strings are nullable,
-    not UNSET) and no discriminated unions — model_validate() should work
-    identically to from_dict() for it. This test proves the plan's
-    model_validate() path is valid for simple models.
+    not UNSET) and no discriminated unions, so model_validate() works identically
+    to from_dict() for it.
 
     For models with UNSET sentinel defaults or discriminated unions (SessionRequest,
     Agent), from_dict() is the correct parsing path.


### PR DESCRIPTION
## What

Re-lands a cleanup commit that was orphaned: it was pushed to `chore/output-only-mirror` (PR #10) **after** that PR had already squash-merged, so it never reached `main`. As a result `main` still publicly leaks internal references.

Strips internal/codegen/mirror framing from the public surface:

- `packages/sdk/tests/test_model_compat.py`, `conftest.py` — drop `SDK-05`, `DEVIATION from plan template`, `make regen-schema`, `model.py.jinja`, `02-RESEARCH.md`.
- `README.md`, `CONTRIBUTING.md` — remove upstream `agent_platform` / codegen-toolchain / "output-only mirror" framing and a stale TS cross-link.
- `.github/{CODEOWNERS,dependabot.yml,codeql.yaml}`, `.gitignore` — drop internal comments.

No generated code touched. 8 files, +33 / -81.

Made with [Cursor](https://cursor.com)