### PR TITLE
Rebuild generated models on import

### DIFF
--- a/packages/sdk/src/agent_platform/__init__.py
+++ b/packages/sdk/src/agent_platform/__init__.py
@@ -11,6 +11,7 @@ instead; the schema-sync workflow restores it after each regeneration.
 
 from __future__ import annotations
 
+import agent_platform.models as _models_pkg
 from agent_platform.client import AuthenticatedClient as _AuthenticatedClient
 from agent_platform.models.agent import Agent
 from agent_platform.models.agent_record import AgentRecord
@@ -63,6 +64,18 @@ __all__ = [
     "SessionRequest",
     "SessionSummary",
 ]
+
+_MODEL_TYPES_NS = {name: getattr(_models_pkg, name) for name in _models_pkg.__all__}
+
+for _model_name in _models_pkg.__all__:
+    _model = getattr(_models_pkg, _model_name)
+    if hasattr(_model, "model_rebuild"):
+        try:
+            _model.model_rebuild(_types_namespace=_MODEL_TYPES_NS)
+        except Exception:
+            pass
+
+del _MODEL_TYPES_NS, _model_name, _model, _models_pkg
 
 
 class Client(_AuthenticatedClient):

--- a/packages/sdk/tests/test_import_rebuilds_models.py
+++ b/packages/sdk/tests/test_import_rebuilds_models.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_package_import_rebuilds_pydantic_models() -> None:
+    script = textwrap.dedent(
+        """
+        from agent_platform import Agent, Browser, SessionRequest
+        from agent_platform.models.page_agent_record import PageAgentRecord
+        from agent_platform.models.user_message_event import UserMessageEvent
+
+        SessionRequest(
+            agent="h/web",
+            messages=[UserMessageEvent(message="Open https://example.com")],
+        )
+        Agent(
+            name="smoke-agent",
+            description="Smoke test agent",
+            environments=[
+                Browser(
+                    id="browser",
+                    kind="web",
+                    headless=True,
+                    width=1280,
+                    height=720,
+                    start_url="https://example.com",
+                )
+            ],
+        )
+        PageAgentRecord.from_dict(
+            {
+                "items": [
+                    {
+                        "id": "00000000-0000-0000-0000-000000000001",
+                        "spec": {
+                            "name": "h/web",
+                            "description": "Web agent.",
+                            "environments": ["h/web"],
+                        },
+                        "reserved": True,
+                        "created_at": "2026-01-01T00:00:00Z",
+                        "updated_at": "2026-01-01T00:00:00Z",
+                    }
+                ],
+                "total": 1,
+                "page": 1,
+            }
+        )
+        """
+    )
+
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- rebuild generated Pydantic models during `agent_platform` import
- add a subprocess regression test that exercises clean import, model instantiation, and agent-page parsing without test-fixture rebuild helpers

Closes #15

## Test
- `uv run ruff check packages/sdk/src/agent_platform/__init__.py packages/sdk/tests/test_import_rebuilds_models.py`
- `uv run pytest packages/sdk/tests/test_import_rebuilds_models.py packages/sdk/tests/test_model_compat.py`