### PR TITLE
Fix Browser quickstart example

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -29,6 +29,7 @@ session = create_session.sync(
             description="A demo agent.",
             instructions="Reply concisely.",
             environments=[Browser(id="browser", kind="web",
+                                  headless=True,
                                   width=1280, height=800,
                                   start_url="https://bing.com")],
         ),


### PR DESCRIPTION
## Summary
- add the required `headless=True` argument to the Python README `Browser(...)` quickstart example

Closes #16

## Test
- `uv run ruff check packages/sdk/README.md` (no Python files under path, command exits successfully)