### PR TITLE
Document source install fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Python developer libraries and tools for [H Company's Agent Platform](https://hc
 
 | Package | Description |
 | --- | --- |
-| [`packages/sdk`](packages/sdk) | Python SDK — sync and async clients, fully typed with Pydantic v2. Published to PyPI as [`agent-platform`](https://pypi.org/project/agent-platform/). |
+| [`packages/sdk`](packages/sdk) | Python SDK — sync and async clients, fully typed with Pydantic v2. Packaged as `agent-platform`. |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ Python developer libraries and tools for [H Company's Agent Platform](https://hc
 
 | Package | Description |
 | --- | --- |
-| [`packages/sdk`](packages/sdk) | Python SDK — sync and async clients, fully typed with Pydantic v2. Packaged as `agent-platform`. |
+| [`packages/sdk`](packages/sdk) | Python SDK source - sync and async clients, fully typed with Pydantic v2. |
+
+Do not install `agent-platform` from public PyPI yet: that name currently
+belongs to an unrelated package and does not provide this SDK's
+`agent_platform` module. Install from this repository until an H-owned public
+package is available.
 
 ## Development
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,5 +1,4 @@
 <p align="center">
-  <a href="https://pypi.org/project/agent-platform/"><img src="https://img.shields.io/pypi/v/agent-platform.svg" alt="PyPI" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
 </p>
 
@@ -9,18 +8,18 @@ Python SDK for [H Company's Agent Platform](https://hcompany.ai). Sync and async
 
 ## Quickstart
 
-```bash
-pip install agent-platform
-```
-
-If the package is not available from your package index yet, install from a
-repository checkout:
+Install from a repository checkout:
 
 ```bash
 git clone https://github.com/hcompai/hai-agents-python.git
 cd hai-agents-python
 pip install ./packages/sdk
 ```
+
+Do not use `pip install agent-platform` from public PyPI yet. That package name
+currently resolves to an unrelated project and will not provide this SDK's
+`agent_platform` module. Use a repository checkout, or an internal package
+index only if your organization has published this SDK there.
 
 ```python
 from agent_platform import Client, Agent, SessionRequest

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -13,6 +13,15 @@ Python SDK for [H Company's Agent Platform](https://hcompany.ai). Sync and async
 pip install agent-platform
 ```
 
+If the package is not available from your package index yet, install from a
+repository checkout:
+
+```bash
+git clone https://github.com/hcompai/hai-agents-python.git
+cd hai-agents-python
+pip install ./packages/sdk
+```
+
 ```python
 from agent_platform import Client, Agent, SessionRequest
 from agent_platform.api.sessions import create_session


### PR DESCRIPTION
## Summary
- stop claiming the SDK is available from public PyPI as `agent-platform`
- remove the PyPI badge from the SDK README
- make the repository checkout install path the primary quickstart
- warn external users that public PyPI `agent-platform==0.1.0` is an unrelated package and does not provide this SDK's `agent_platform` module

Closes #17

## Test
- `git diff --check`
- verified the public PyPI project record for `agent-platform` currently points to an unrelated package
