### PR TITLE
ci: add PyPI publish workflow (Trusted Publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,115 @@
+name: Publish
+
+# Publishes packages/sdk (hai-agents) to PyPI via Trusted Publishing (OIDC, no token).
+# Tag push v* -> PyPI. workflow_dispatch -> TestPyPI dry-run (or PyPI on demand).
+# The PyPI/TestPyPI pending publishers must point at workflow `publish.yml`,
+# environments `release` / `testpypi`.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Index to publish to"
+        type: choice
+        options: [testpypi, pypi]
+        default: testpypi
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - run: uv sync
+      - name: ruff
+        run: uv run ruff check .
+      - name: smoke import
+        run: uv run python -c "from hai_agents import Client, AsyncClient; Client(api_key='hk-smoke', base_url='http://x'); print('import OK')"
+
+  build:
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - name: assert tag matches pyproject version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg=$(uv run --no-project python -c "import tomllib; print(tomllib.load(open('packages/sdk/pyproject.toml','rb'))['project']['version'])")
+          if [ "$tag" != "$pkg" ]; then
+            echo "tag v$tag does not match pyproject version $pkg" >&2
+            exit 1
+          fi
+      - name: build
+        run: uv build --package hai-agents
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-pypi:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v') || inputs.target == 'pypi'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write  # OIDC token for Trusted Publishers + Sigstore attestations
+      attestations: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true
+
+  publish-testpypi:
+    needs: build
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          attestations: true
+
+  release:
+    needs: publish-pypi
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          draft: false


### PR DESCRIPTION
## Summary
Adds `.github/workflows/publish.yml` so `packages/sdk` (**hai-agents**) can be published to PyPI via **Trusted Publishing** (OIDC, no long-lived token).

- **Tag push `v*`** -> build + publish to **PyPI** (`release` env) + cut a GitHub Release.
- **`workflow_dispatch`** -> **TestPyPI** dry-run by default (`testpypi` env), or PyPI on demand.
- Build runs `uv build --package hai-agents` from the workspace root (uv writes to repo-root `dist/`).
- Guard: on tag pushes, the tag (`vX.Y.Z`) must match `packages/sdk/pyproject.toml` version or the build fails.
- `quality` job runs `ruff check` + a real `from hai_agents import Client, AsyncClient` smoke import before anything is built.

Matches the PyPI/TestPyPI **pending publishers** already configured (repo `hcompai/hai-agents-python`, workflow `publish.yml`, environments `release` / `testpypi`).

## Why draft
Holding until the public API stabilizes (breaking flatten/web-only PRs still settling upstream in `agent_platform`). Do not merge until a version is ready to ship.

## Test plan
- [x] `uv build --package hai-agents` builds sdist+wheel into repo-root `dist/`
- [x] Fresh-venv install of the built wheel imports `hai_agents` (`from hai_agents import Client, AsyncClient`)
- [ ] First real release: bump `packages/sdk/pyproject.toml`, tag `vX.Y.Z`, confirm OIDC publish to PyPI
- [ ] `workflow_dispatch` -> TestPyPI dry-run succeeds end to end

Made with [Cursor](https://cursor.com)