### PR TITLE
test: drop AgentRecord round-trip for v0.4.0 agent flatten

### DIFF
--- a/packages/sdk/tests/conftest.py
+++ b/packages/sdk/tests/conftest.py
@@ -20,7 +20,6 @@ from typing import Any, Dict
 import pytest
 
 from hai_agents.models.agent import Agent
-from hai_agents.models.agent_record import AgentRecord
 from hai_agents.models.session import Session
 from hai_agents.models.session_request import SessionRequest
 from hai_agents.models.session_status import SessionStatus
@@ -142,16 +141,4 @@ def agent_payload() -> Dict[str, Any]:
         "name": "test-agent",
         "description": "A test agent for roundtrip validation.",
         "environments": [],
-    }
-
-
-@pytest.fixture
-def agent_record_payload(agent_payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Canonical AgentRecord dict — catalog row (id + spec + reserved + timestamps)."""
-    return {
-        "id": "00000000-0000-0000-0000-000000000002",
-        "spec": agent_payload,
-        "reserved": False,
-        "created_at": "2024-01-01T00:00:00+00:00",
-        "updated_at": "2024-06-01T12:00:00+00:00",
     }

--- a/packages/sdk/tests/test_model_compat.py
+++ b/packages/sdk/tests/test_model_compat.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any, Dict
 
 from hai_agents.models.agent import Agent
-from hai_agents.models.agent_record import AgentRecord
 from hai_agents.models.session import Session
 from hai_agents.models.session_request import SessionRequest
 from hai_agents.models.skill_record import SkillRecord
@@ -91,12 +90,6 @@ def test_agent_roundtrip(agent_payload: Dict[str, Any]) -> None:
     """
     serialized = _roundtrip(Agent, agent_payload)
     assert_json_equal(serialized, agent_payload)
-
-
-def test_agent_record_roundtrip(agent_record_payload: Dict[str, Any]) -> None:
-    """AgentRecord (catalog row: id + spec + reserved + timestamps) round-trips."""
-    serialized = _roundtrip(AgentRecord, agent_record_payload)
-    assert_json_equal(serialized, agent_record_payload)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The agent flatten removes AgentRecord (id + spec + reserved + timestamps); the public agent is now the flat Agent spec, already covered by test_agent_roundtrip. Remove the dead import, fixture, and round-trip so the hand-written test suite imports cleanly against the flattened SDK.