### PR TITLE
chore(sdk): sync to agent_platform@61fd672 (v0.5.1)

### DIFF
--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python SDK for H Company's Agent Platform — sync and async clients, fully typed with Pydantic v2."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/packages/sdk/src/hai_agents/__init__.py
+++ b/packages/sdk/src/hai_agents/__init__.py
@@ -13,18 +13,39 @@ from __future__ import annotations
 
 from hai_agents.client import AuthenticatedClient as _AuthenticatedClient
 from hai_agents.models.agent import Agent
+from hai_agents.models.agent_record import AgentRecord
 from hai_agents.models.browser import Browser
+from hai_agents.models.create_agent import CreateAgent
+from hai_agents.models.create_environment import CreateEnvironment
+from hai_agents.models.create_skill import CreateSkill
+from hai_agents.models.environment_record import EnvironmentRecord
 from hai_agents.models.session import Session
 from hai_agents.models.session_request import SessionRequest
 from hai_agents.models.session_summary import SessionSummary
 from hai_agents.models.skill import Skill
+from hai_agents.models.skill_record import SkillRecord
+from hai_agents.models.update_environment import UpdateEnvironment
+from hai_agents.models.update_skill import UpdateSkill
 
 __all__ = [
     "Client",
     "AsyncClient",
+    # Agent
     "Agent",
+    "AgentRecord",
+    "CreateAgent",
+    # Environment specs (discriminated union members)
     "Browser",
+    # Environment catalog
+    "EnvironmentRecord",
+    "CreateEnvironment",
+    "UpdateEnvironment",
+    # Skill
     "Skill",
+    "SkillRecord",
+    "CreateSkill",
+    "UpdateSkill",
+    # Session
     "Session",
     "SessionRequest",
     "SessionSummary",


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.5.1` (patch — additive change)
**Upstream:** agent_platform@61fd672
