### PR TITLE
chore(sdk): sync to agent_platform@d96677b (v0.5.2)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1544,7 +1544,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Page_Annotated_Union_Browser__CodeSandbox__MCP__Memory___FieldInfo_annotation_NoneType__required_True__discriminator__kind____"
+                  "$ref": "#/components/schemas/EnvironmentPage"
                 }
               }
             }
@@ -2199,6 +2199,43 @@
         "title": "Browser",
         "description": "Browser environment."
       },
+      "EnvironmentPage": {
+        "properties": {
+          "items": {
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/Browser"
+                }
+              ],
+              "discriminator": {
+                "propertyName": "kind",
+                "mapping": {
+                  "web": "#/components/schemas/Browser"
+                }
+              }
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "page"
+        ],
+        "title": "EnvironmentPage",
+        "description": "Named page subclass so OpenAPI emits a clean ``EnvironmentPage`` schema name.\n\n``Environment`` is ``Annotated[Browser | CodeSandbox | MCP | Memory, Field(discriminator=\"kind\")]``\nand has no ``__name__``. Without this subclass, Pydantic titles ``Page[Environment]``\nby repr()ing the type parameter, producing a 95-char schema name that leaks\nPydantic FieldInfo into generated SDKs."
+      },
       "Feedback": {
         "properties": {
           "success": {
@@ -2427,42 +2464,6 @@
           "page"
         ],
         "title": "Page[Agent]"
-      },
-      "Page_Annotated_Union_Browser__CodeSandbox__MCP__Memory___FieldInfo_annotation_NoneType__required_True__discriminator__kind____": {
-        "properties": {
-          "items": {
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/Browser"
-                }
-              ],
-              "discriminator": {
-                "propertyName": "kind",
-                "mapping": {
-                  "web": "#/components/schemas/Browser"
-                }
-              }
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "page": {
-            "type": "integer",
-            "title": "Page"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items",
-          "total",
-          "page"
-        ],
-        "title": "Page[Annotated[Union[Browser, CodeSandbox, MCP, Memory], FieldInfo(annotation=NoneType, required=True, discriminator='kind')]]"
       },
       "Page_SessionSummary_": {
         "properties": {

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "0.5.1"
+version = "0.5.2"
 description = "Python SDK for H Company's Agent Platform — sync and async clients, fully typed with Pydantic v2."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/packages/sdk/src/hai_agents/api/environments/list_environments.py
+++ b/packages/sdk/src/hai_agents/api/environments/list_environments.py
@@ -6,11 +6,9 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.environment_page import EnvironmentPage
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_environments_sort_type_0_item import ListEnvironmentsSortType0Item
-from ...models.page_annotated_union_browser_code_sandbox_mcp_memory_field_infoannotation_none_type_required_true_discriminatorkind import (
-    PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind,
-)
 from ...types import UNSET, Response, Unset
 
 
@@ -53,15 +51,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-    HTTPValidationError
-    | PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind
-    | None
-):
+) -> EnvironmentPage | HTTPValidationError | None:
     if response.status_code == 200:
-        response_200 = PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind.from_dict(
-            response.json()
-        )
+        response_200 = EnvironmentPage.from_dict(response.json())
 
         return response_200
 
@@ -78,10 +70,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-    HTTPValidationError
-    | PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind
-]:
+) -> Response[EnvironmentPage | HTTPValidationError]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -96,10 +85,7 @@ def sync_detailed(
     page: int | Unset = 1,
     size: int | Unset = 10,
     sort: list[ListEnvironmentsSortType0Item] | None | Unset = UNSET,
-) -> Response[
-    HTTPValidationError
-    | PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind
-]:
+) -> Response[EnvironmentPage | HTTPValidationError]:
     """List Environments
 
      List reserved + caller's org environments.
@@ -114,7 +100,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind]
+        Response[EnvironmentPage | HTTPValidationError]
     """
 
     kwargs = _get_kwargs(
@@ -136,11 +122,7 @@ def sync(
     page: int | Unset = 1,
     size: int | Unset = 10,
     sort: list[ListEnvironmentsSortType0Item] | None | Unset = UNSET,
-) -> (
-    HTTPValidationError
-    | PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind
-    | None
-):
+) -> EnvironmentPage | HTTPValidationError | None:
     """List Environments
 
      List reserved + caller's org environments.
@@ -155,7 +137,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind
+        EnvironmentPage | HTTPValidationError
     """
 
     return sync_detailed(
@@ -172,10 +154,7 @@ async def asyncio_detailed(
     page: int | Unset = 1,
     size: int | Unset = 10,
     sort: list[ListEnvironmentsSortType0Item] | None | Unset = UNSET,
-) -> Response[
-    HTTPValidationError
-    | PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind
-]:
+) -> Response[EnvironmentPage | HTTPValidationError]:
     """List Environments
 
      List reserved + caller's org environments.
@@ -190,7 +169,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind]
+        Response[EnvironmentPage | HTTPValidationError]
     """
 
     kwargs = _get_kwargs(
@@ -210,11 +189,7 @@ async def asyncio(
     page: int | Unset = 1,
     size: int | Unset = 10,
     sort: list[ListEnvironmentsSortType0Item] | None | Unset = UNSET,
-) -> (
-    HTTPValidationError
-    | PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind
-    | None
-):
+) -> EnvironmentPage | HTTPValidationError | None:
     """List Environments
 
      List reserved + caller's org environments.
@@ -229,7 +204,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind
+        EnvironmentPage | HTTPValidationError
     """
 
     return (

--- a/packages/sdk/src/hai_agents/models/__init__.py
+++ b/packages/sdk/src/hai_agents/models/__init__.py
@@ -2,6 +2,7 @@
 
 from .agent import Agent
 from .browser import Browser
+from .environment_page import EnvironmentPage
 from .feedback import Feedback
 from .http_validation_error import HTTPValidationError
 from .list_agents_sort_type_0_item import ListAgentsSortType0Item
@@ -14,9 +15,6 @@ from .metrics import Metrics
 from .model_cost import ModelCost
 from .model_usage import ModelUsage
 from .page_agent import PageAgent
-from .page_annotated_union_browser_code_sandbox_mcp_memory_field_infoannotation_none_type_required_true_discriminatorkind import (
-    PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind,
-)
 from .page_session_summary import PageSessionSummary
 from .page_skill import PageSkill
 from .page_trajectory_event import PageTrajectoryEvent
@@ -41,6 +39,7 @@ from .validation_error_context import ValidationErrorContext
 __all__ = (
     "Agent",
     "Browser",
+    "EnvironmentPage",
     "Feedback",
     "HTTPValidationError",
     "ListAgentsSortType0Item",
@@ -53,7 +52,6 @@ __all__ = (
     "ModelCost",
     "ModelUsage",
     "PageAgent",
-    "PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind",
     "PageSessionSummary",
     "PageSkill",
     "PageTrajectoryEvent",

--- a/packages/sdk/src/hai_agents/models/environment_page.py
+++ b/packages/sdk/src/hai_agents/models/environment_page.py
@@ -7,17 +7,21 @@ from pydantic import BaseModel, ConfigDict
 
 from ..types import UNSET, Unset
 
-T = TypeVar(
-    "T", bound="PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind"
-)
+T = TypeVar("T", bound="EnvironmentPage")
 
 
-class PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRequiredTrueDiscriminatorkind(BaseModel):
-    """
-    Attributes:
-        items (list[Browser]):
-        total (int):
-        page (int):
+class EnvironmentPage(BaseModel):
+    """Named page subclass so OpenAPI emits a clean ``EnvironmentPage`` schema name.
+
+    ``Environment`` is ``Annotated[Browser | CodeSandbox | MCP | Memory, Field(discriminator="kind")]``
+    and has no ``__name__``. Without this subclass, Pydantic titles ``Page[Environment]``
+    by repr()ing the type parameter, producing a 95-char schema name that leaks
+    Pydantic FieldInfo into generated SDKs.
+
+        Attributes:
+            items (list[Browser]):
+            total (int):
+            page (int):
     """
 
     model_config = ConfigDict(
@@ -72,14 +76,14 @@ class PageAnnotatedUnionBrowserCodeSandboxMCPMemoryFieldInfoannotationNoneTypeRe
 
         page = d.pop("page")
 
-        page_annotated_union_browser_code_sandbox_mcp_memory_field_infoannotation_none_type_required_true_discriminatorkind = cls(
+        environment_page = cls(
             items=items,
             total=total,
             page=page,
         )
 
-        page_annotated_union_browser_code_sandbox_mcp_memory_field_infoannotation_none_type_required_true_discriminatorkind.additional_properties = d
-        return page_annotated_union_browser_code_sandbox_mcp_memory_field_infoannotation_none_type_required_true_discriminatorkind
+        environment_page.additional_properties = d
+        return environment_page
 
     @property
     def additional_keys(self) -> list[str]:


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.5.2` (patch — additive change)
**Upstream:** agent_platform@d96677b
