### PR TITLE
chore(sdk): sync to agent_platform@088b35d (v0.5.4)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2617,6 +2617,10 @@
           "status": {
             "$ref": "#/components/schemas/SessionStatus"
           },
+          "latest_answer": {
+            "title": "Latest Answer",
+            "description": "The agent's most recent final answer: free-form text, or structured data when the agent runs with a custom answer format. Null until the agent first answers. Mirrors the answer streamed from the changes endpoint, surfaced here for non-interactive runs."
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "0.5.3"
+version = "0.5.4"
 description = "Python SDK for H Company's Agent Platform — sync and async clients, fully typed with Pydantic v2."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/packages/sdk/src/hai_agents/models/session.py
+++ b/packages/sdk/src/hai_agents/models/session.py
@@ -21,6 +21,9 @@ class Session(BaseModel):
         request (SessionRequest): ``POST /api/v2/sessions`` body.
         status (SessionStatus): ``GET /api/v2/sessions/{id}/status`` response.
         created_at (datetime.datetime):
+        latest_answer (Any | Unset): The agent's most recent final answer: free-form text, or structured data when the
+            agent runs with a custom answer format. Null until the agent first answers. Mirrors the answer streamed from the
+            changes endpoint, surfaced here for non-interactive runs.
         started_at (datetime.datetime | None | Unset):
         finished_at (datetime.datetime | None | Unset):
     """
@@ -36,6 +39,7 @@ class Session(BaseModel):
     request: SessionRequest
     status: SessionStatus
     created_at: datetime.datetime
+    latest_answer: Any | Unset = UNSET
     started_at: datetime.datetime | None | Unset = UNSET
     finished_at: datetime.datetime | None | Unset = UNSET
 
@@ -50,6 +54,8 @@ class Session(BaseModel):
         status = self.status.to_dict()
 
         created_at = self.created_at.isoformat()
+
+        latest_answer = self.latest_answer
 
         started_at: None | str | Unset
         if isinstance(self.started_at, Unset):
@@ -77,6 +83,8 @@ class Session(BaseModel):
                 "created_at": created_at,
             }
         )
+        if latest_answer is not UNSET:
+            field_dict["latest_answer"] = latest_answer
         if started_at is not UNSET:
             field_dict["started_at"] = started_at
         if finished_at is not UNSET:
@@ -97,6 +105,8 @@ class Session(BaseModel):
         status = SessionStatus.from_dict(d.pop("status"))
 
         created_at = isoparse(d.pop("created_at"))
+
+        latest_answer = d.pop("latest_answer", UNSET)
 
         def _parse_started_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -137,6 +147,7 @@ class Session(BaseModel):
             request=request,
             status=status,
             created_at=created_at,
+            latest_answer=latest_answer,
             started_at=started_at,
             finished_at=finished_at,
         )


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.5.4` (patch — additive change)
**Upstream:** agent_platform@088b35d
