### PR TITLE
ci: add PyPI trusted-publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Verify release tag matches package version
+        if: github.event_name == 'release'
+        run: |
+          VERSION=$(grep -m1 '^version = ' packages/sdk/pyproject.toml | sed -E 's/version = "(.*)"/\1/')
+          TAG="${GITHUB_REF_NAME#v}"
+          if [ "$VERSION" != "$TAG" ]; then
+            echo "::error::Release tag '$TAG' does not match packages/sdk/pyproject.toml version '$VERSION'."
+            exit 1
+          fi
+          echo "Publishing hai-agents $VERSION"
+
+      - name: Build sdist and wheel
+        run: uv build packages/sdk --out-dir dist
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds `.github/workflows/publish.yml` so `hai-agents` can be published to PyPI via OIDC trusted publishing (no API token).

## What it does
- Triggers on a published GitHub Release (and `workflow_dispatch` for manual runs).
- Builds the sdist + wheel from `packages/sdk` with `uv build`.
- Publishes via `pypa/gh-action-pypi-publish` using the `release` environment and `id-token: write` (matches the PyPI pending publisher already configured for this repo: workflow `publish.yml`, environment `release`).
- On release events, guards that the tag (`vX.Y.Z`) matches `packages/sdk/pyproject.toml`'s version.

Lives in the mirror (not the codegen templates) like `test.yaml`/`codeql.yaml`; `generate.sh` never touches `.github/`, so it survives SDK syncs.

## Before first publish
1. Merge this PR.
2. (Recommended) Create the `release` environment under repo Settings → Environments, optionally with a required reviewer to gate releases.
3. Cut a GitHub Release `v0.6.0`. The workflow builds and publishes; the PyPI pending publisher then activates and creates the `hai-agents` project.

## Test plan
- [ ] Merge, then run the workflow via `workflow_dispatch` against a TestPyPI dry run, or cut `v0.6.0` and confirm the publish job authenticates via OIDC and uploads.

Made with [Cursor](https://cursor.com)