### PR TITLE
chore(sdk): reset version to 0.1.0

### DIFF
--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "0.6.0"
+version = "0.1.0"
 description = "Python SDK for H Company's Agent Platform — sync and async clients, fully typed with Pydantic v2."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "hai-agents"
-version = "0.5.0"
+version = "0.1.0"
 source = { editable = "packages/sdk" }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
First public release version. Resets `0.6.0` (auto-bumped by the sync bot, never published) down to `0.1.0` so the initial PyPI release starts at a conventional, beta-appropriate version. Matches `hai-agents-ts`.

The codegen bump logic reads the mirror's current version and increments, so future syncs continue from `0.1.0` (patch -> `0.1.1`, breaking -> `0.2.0`).

Made with [Cursor](https://cursor.com)