### PR TITLE
chore: pre-release packaging cleanup

### DIFF
--- a/.github/workflows/check-uv-lock-private-refs.yaml
+++ b/.github/workflows/check-uv-lock-private-refs.yaml
@@ -1,10 +1,5 @@
 name: Check uv.lock for private CodeArtifact references
 
-# Fails if uv.lock leaks `https://*.codeartifact.*.amazonaws.com/...` URLs,
-# which happens when someone runs `uv lock` / `uv sync` with
-# UV_EXTRA_INDEX_URL pointing at the private hai registry. This repo will
-# be public, so any private-registry URL in the lockfile is a leak.
-
 on:
   pull_request:
     paths:
@@ -26,8 +21,6 @@ jobs:
 
       - name: Scan uv.lock
         run: |
-          # Match only real private CodeArtifact URLs, not package names like
-          # `mypy-boto3-codeartifact` or extras like `boto3-stubs[codeartifact]`.
           if grep -qE "codeartifact\.[^\"']*\.amazonaws\.com" uv.lock; then
             echo "::error::uv.lock contains private CodeArtifact URLs."
             echo ""

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  Python SDK for <a href="https://hcompany.ai">H Company's Agent API</a>. Launch autonomous agents that browse the web and use tools, stream their progress, and steer them mid-run. Fully typed, with sync and async clients.
+  Python SDK for the H Company Agent API. Launch autonomous agents powered by Holo, stream their progress, and steer them mid-run.
 </p>
 
 <p align="center">
@@ -21,6 +21,8 @@
   <a href="https://portal.hcompany.ai">Get an API key</a>
   &nbsp;·&nbsp;
   <a href="https://pypi.org/project/hai-agents/">PyPI</a>
+  &nbsp;·&nbsp;
+  <a href="https://hcompany.ai">H Company</a>
 </p>
 
 ## Install
@@ -145,8 +147,8 @@ print(f"limit: {MAX_REQUEST_BYTES} bytes")
 
 ## Documentation
 
-- [Agent API documentation](https://hub.hcompany.ai/agent-api) — guides, core concepts, and the full API reference
-- [Developer portal](https://portal.hcompany.ai) — manage API keys and usage
+- [Agent API documentation](https://hub.hcompany.ai/agent-api): guides, core concepts, and the full API reference
+- [Developer portal](https://portal.hcompany.ai): manage API keys and usage
 - [H Company](https://hcompany.ai)
 
 ## License

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  Python SDK for <a href="https://hcompany.ai">H Company's Agent API</a>. Launch autonomous agents that browse the web and use tools, stream their progress, and steer them mid-run. Fully typed, with sync and async clients.
+  Python SDK for the H Company Agent API. Launch autonomous agents powered by Holo, stream their progress, and steer them mid-run.
 </p>
 
 <p align="center">
@@ -21,6 +21,8 @@
   <a href="https://portal.hcompany.ai">Get an API key</a>
   &nbsp;·&nbsp;
   <a href="https://pypi.org/project/hai-agents/">PyPI</a>
+  &nbsp;·&nbsp;
+  <a href="https://hcompany.ai">H Company</a>
 </p>
 
 ## Install
@@ -145,8 +147,8 @@ print(f"limit: {MAX_REQUEST_BYTES} bytes")
 
 ## Documentation
 
-- [Agent API documentation](https://hub.hcompany.ai/agent-api) — guides, core concepts, and the full API reference
-- [Developer portal](https://portal.hcompany.ai) — manage API keys and usage
+- [Agent API documentation](https://hub.hcompany.ai/agent-api): guides, core concepts, and the full API reference
+- [Developer portal](https://portal.hcompany.ai): manage API keys and usage
 - [H Company](https://hcompany.ai)
 
 ## License

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "hai-agents"
 version = "0.1.0"
-description = "Python SDK for H Company's Agent Platform — sync and async clients, fully typed with Pydantic v2."
+description = "Python SDK for H Company's Agent API: autonomous agents powered by Holo."
 requires-python = ">=3.10"
 readme = "README.md"
 authors = [{name = "H Company", email = "contact@hcompany.ai"}]
@@ -35,17 +35,13 @@ dependencies = [
 Homepage = "https://hcompany.ai"
 Repository = "https://github.com/hcompai/hai-agents-python"
 Issues = "https://github.com/hcompai/hai-agents-python/issues"
-Documentation = "https://hub.hcompany.ai"
+Documentation = "https://hub.hcompany.ai/agent-api"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/hai_agents"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-# By default, integration tests are excluded — they hit a live API. Run them
-# explicitly with `pytest -m integration`. The nightly CI workflow uses
-# `-m "integration and not slow"` for the cheap tier and the full marker
-# for the slow tier.
 addopts = "-ra -q -m 'not integration'"
 markers = [
   "integration: tests that hit a live Agent Platform backend (requires HAI_API_KEY_TEST)",


### PR DESCRIPTION
## Summary
- **`py.typed`**: ship the PEP 561 marker so `mypy`/`pyright` actually use the inline annotations (the package advertises `Typing :: Typed`). The durable codegen fix is in hcompai/agent_platform#1197; this lands it in the package for 0.1.0.
- **Metadata**: point `pyproject` `Documentation` at `https://hub.hcompany.ai/agent-api` and refresh the `description`.
- **README**: tighten the hero ("autonomous agents powered by Holo", no longer web-only), add an `H Company` link to the nav, and purge em dashes. Mirrored to the repo root.
- **Comments**: drop internal-rationale comments from hand-written config (`pyproject` pytest block, `check-uv-lock` workflow which referenced internal infra).

Made with [Cursor](https://cursor.com)