### PR TITLE
docs: trim README to essentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  Python SDK for the H Company Agent API. Launch autonomous agents powered by Holo, stream their progress, and steer them mid-run.
+  Python SDK for the <a href="https://hcompany.ai">H Company</a> <a href="https://hub.hcompany.ai/agent-api">Agent API</a>. Launch autonomous agents powered by Holo, stream their progress, and steer them mid-run.
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="https://hcompany.ai">H Company</a>
 </p>
 
-## Install
+## Installation
 
 ```bash
 pip install hai-agents
@@ -35,9 +35,7 @@ Requires Python 3.10 or newer. Grab an API key at [portal.hcompany.ai](https://p
 
 ## Quickstart
 
-Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own
-browser, and describe the task in plain language. `run_session_until_done` polls
-until the agent reaches a terminal state and returns the final answer.
+Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `run_session_until_done` polls until the agent finishes and returns the final answer.
 
 ```python
 from hai_agents import Client, run_session_until_done
@@ -54,102 +52,15 @@ print(result.status)  # "completed"
 print(result.answer)
 ```
 
-Tune the run with `timeout_seconds`, `poll_backoff_seconds`, and `include_events`.
-An `AsyncClient` (with `async_run_session_until_done`) mirrors this surface for asyncio.
-
-## Create a session and poll it yourself
-
-For finer control, create the session and read it directly. `get_session_status`
-is a lightweight liveness check; the final `answer` lands in `get_session_changes`.
-
-```python
-session = client.sessions.create_session(
-    agent="h/web-surfer-holo3-1-35b",
-    messages="What are the top 3 stories on Hacker News right now?",
-)
-
-status = client.sessions.get_session_status(session.id)
-print(status.status, status.steps)
-
-changes = client.sessions.get_session_changes(session.id, from_index=0)
-print(changes.answer)
-```
-
-## Steer a running session
-
-Send a message to redirect the agent mid-run, or record feedback once it finishes.
-
-```python
-from hai_agents import SendSessionMessagesRequestBody_UserMessage
-
-client.sessions.send_session_messages(
-    session.id,
-    request=SendSessionMessagesRequestBody_UserMessage(
-        message="Only consider stories posted in the last 24 hours.",
-    ),
-)
-
-client.sessions.submit_session_feedback(
-    session.id,
-    success=True,
-    message="The answer matched the front page.",
-)
-```
-
-`cancel_session` asks the platform to interrupt the run. The session may still
-report `running` briefly while the worker stops; poll until it reaches a terminal
-state such as `interrupted`.
-
-```python
-client.sessions.cancel_session(session.id)
-```
-
-## Error handling
-
-Operations raise `ApiError` on a non-2xx response; inspect `status_code` and `body`.
-
-```python
-from hai_agents.core import ApiError
-
-try:
-    session = client.sessions.get_session(session_id)
-    print(session.status)
-except ApiError as err:
-    print(err.status_code, err.body)
-    raise
-```
-
-## Regions
-
-The client targets the EU region by default. Select a region with `environment`,
-or point at a custom URL with `base_url`.
-
-```python
-from hai_agents import Client, HaiAgentsEnvironment
-
-us_client = Client(token="YOUR_API_KEY", environment=HaiAgentsEnvironment.US)
-
-proxied = Client(token="YOUR_API_KEY", base_url="https://my-proxy.example.com")
-```
-
-## Request size limit
-
-The platform rejects request bodies above 5MB. `run_session_until_done` enforces
-this on the create payload; for ad-hoc requests, validate first to fail fast with
-a clear message instead of a server error.
-
-```python
-from hai_agents import MAX_REQUEST_BYTES, assert_request_under_limit
-
-assert_request_under_limit({"agent": "h/web-surfer-holo3-1-35b", "messages": messages})
-print(f"limit: {MAX_REQUEST_BYTES} bytes")
-```
+An `AsyncClient` mirrors this API for asyncio. Streaming progress, steering a live session, regions, structured output, and error handling are all covered in the documentation.
 
 ## Documentation
 
-- [Agent API documentation](https://hub.hcompany.ai/agent-api): guides, core concepts, and the full API reference
-- [Developer portal](https://portal.hcompany.ai): manage API keys and usage
-- [H Company](https://hcompany.ai)
+Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**.
+
+- [Quickstart](https://hub.hcompany.ai/agent-api/quickstart)
+- [Observe and steer a session](https://hub.hcompany.ai/agent-api/observe-and-steer)
+- [Multi-agent orchestration](https://hub.hcompany.ai/agent-api/multi-agent)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -35,18 +35,16 @@ Requires Python 3.10 or newer. Grab an API key at [portal.hcompany.ai](https://p
 
 ## Quickstart
 
-List the agents available to your account, then launch one with a task described in plain language. Built-in agents, such as a web surfer that ships with its own browser, live under the `h/` namespace. `run_session_until_done` polls until the agent finishes and returns the final answer.
+Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `run_session_until_done` polls until the agent finishes and returns the final answer.
 
 ```python
 from hai_agents import Client, run_session_until_done
 
 client = Client(token="YOUR_API_KEY")
 
-agents = client.agents.list_agents().items
-
 result = run_session_until_done(
     client,
-    agent=agents[0].name,
+    agent="h/web-surfer-holo3-1-35b",
     messages="What are the top 3 stories on Hacker News right now?",
 )
 

--- a/README.md
+++ b/README.md
@@ -35,16 +35,18 @@ Requires Python 3.10 or newer. Grab an API key at [portal.hcompany.ai](https://p
 
 ## Quickstart
 
-Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `run_session_until_done` polls until the agent finishes and returns the final answer.
+List the agents available to your account, then launch one with a task described in plain language. Built-in agents, such as a web surfer that ships with its own browser, live under the `h/` namespace. `run_session_until_done` polls until the agent finishes and returns the final answer.
 
 ```python
 from hai_agents import Client, run_session_until_done
 
 client = Client(token="YOUR_API_KEY")
 
+agents = client.agents.list_agents().items
+
 result = run_session_until_done(
     client,
-    agent="h/web-surfer-holo3-1-35b",
+    agent=agents[0].name,
     messages="What are the top 3 stories on Hacker News right now?",
 )
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
   &nbsp;·&nbsp;
   <a href="https://pypi.org/project/hai-agents/">PyPI</a>
   &nbsp;·&nbsp;
+  <a href="https://github.com/hcompai/hai-agents-ts">TypeScript SDK</a>
+  &nbsp;·&nbsp;
   <a href="https://hcompany.ai">H Company</a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -54,15 +54,11 @@ print(result.status)  # "completed"
 print(result.answer)
 ```
 
-An `AsyncClient` mirrors this API for asyncio. Streaming progress, steering a live session, regions, structured output, and error handling are all covered in the documentation.
+An `AsyncClient` mirrors this API for asyncio.
 
 ## Documentation
 
-Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**.
-
-- [Quickstart](https://hub.hcompany.ai/agent-api/quickstart)
-- [Observe and steer a session](https://hub.hcompany.ai/agent-api/observe-and-steer)
-- [Multi-agent orchestration](https://hub.hcompany.ai/agent-api/multi-agent)
+Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**, covering streaming progress, steering a live session, regions, structured output, and error handling.
 
 ## License
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  Python SDK for the H Company Agent API. Launch autonomous agents powered by Holo, stream their progress, and steer them mid-run.
+  Python SDK for the <a href="https://hcompany.ai">H Company</a> <a href="https://hub.hcompany.ai/agent-api">Agent API</a>. Launch autonomous agents powered by Holo, stream their progress, and steer them mid-run.
 </p>
 
 <p align="center">

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -25,7 +25,7 @@
   <a href="https://hcompany.ai">H Company</a>
 </p>
 
-## Install
+## Installation
 
 ```bash
 pip install hai-agents
@@ -35,9 +35,7 @@ Requires Python 3.10 or newer. Grab an API key at [portal.hcompany.ai](https://p
 
 ## Quickstart
 
-Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own
-browser, and describe the task in plain language. `run_session_until_done` polls
-until the agent reaches a terminal state and returns the final answer.
+Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `run_session_until_done` polls until the agent finishes and returns the final answer.
 
 ```python
 from hai_agents import Client, run_session_until_done
@@ -54,102 +52,15 @@ print(result.status)  # "completed"
 print(result.answer)
 ```
 
-Tune the run with `timeout_seconds`, `poll_backoff_seconds`, and `include_events`.
-An `AsyncClient` (with `async_run_session_until_done`) mirrors this surface for asyncio.
-
-## Create a session and poll it yourself
-
-For finer control, create the session and read it directly. `get_session_status`
-is a lightweight liveness check; the final `answer` lands in `get_session_changes`.
-
-```python
-session = client.sessions.create_session(
-    agent="h/web-surfer-holo3-1-35b",
-    messages="What are the top 3 stories on Hacker News right now?",
-)
-
-status = client.sessions.get_session_status(session.id)
-print(status.status, status.steps)
-
-changes = client.sessions.get_session_changes(session.id, from_index=0)
-print(changes.answer)
-```
-
-## Steer a running session
-
-Send a message to redirect the agent mid-run, or record feedback once it finishes.
-
-```python
-from hai_agents import SendSessionMessagesRequestBody_UserMessage
-
-client.sessions.send_session_messages(
-    session.id,
-    request=SendSessionMessagesRequestBody_UserMessage(
-        message="Only consider stories posted in the last 24 hours.",
-    ),
-)
-
-client.sessions.submit_session_feedback(
-    session.id,
-    success=True,
-    message="The answer matched the front page.",
-)
-```
-
-`cancel_session` asks the platform to interrupt the run. The session may still
-report `running` briefly while the worker stops; poll until it reaches a terminal
-state such as `interrupted`.
-
-```python
-client.sessions.cancel_session(session.id)
-```
-
-## Error handling
-
-Operations raise `ApiError` on a non-2xx response; inspect `status_code` and `body`.
-
-```python
-from hai_agents.core import ApiError
-
-try:
-    session = client.sessions.get_session(session_id)
-    print(session.status)
-except ApiError as err:
-    print(err.status_code, err.body)
-    raise
-```
-
-## Regions
-
-The client targets the EU region by default. Select a region with `environment`,
-or point at a custom URL with `base_url`.
-
-```python
-from hai_agents import Client, HaiAgentsEnvironment
-
-us_client = Client(token="YOUR_API_KEY", environment=HaiAgentsEnvironment.US)
-
-proxied = Client(token="YOUR_API_KEY", base_url="https://my-proxy.example.com")
-```
-
-## Request size limit
-
-The platform rejects request bodies above 5MB. `run_session_until_done` enforces
-this on the create payload; for ad-hoc requests, validate first to fail fast with
-a clear message instead of a server error.
-
-```python
-from hai_agents import MAX_REQUEST_BYTES, assert_request_under_limit
-
-assert_request_under_limit({"agent": "h/web-surfer-holo3-1-35b", "messages": messages})
-print(f"limit: {MAX_REQUEST_BYTES} bytes")
-```
+An `AsyncClient` mirrors this API for asyncio. Streaming progress, steering a live session, regions, structured output, and error handling are all covered in the documentation.
 
 ## Documentation
 
-- [Agent API documentation](https://hub.hcompany.ai/agent-api): guides, core concepts, and the full API reference
-- [Developer portal](https://portal.hcompany.ai): manage API keys and usage
-- [H Company](https://hcompany.ai)
+Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**.
+
+- [Quickstart](https://hub.hcompany.ai/agent-api/quickstart)
+- [Observe and steer a session](https://hub.hcompany.ai/agent-api/observe-and-steer)
+- [Multi-agent orchestration](https://hub.hcompany.ai/agent-api/multi-agent)
 
 ## License
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -35,18 +35,16 @@ Requires Python 3.10 or newer. Grab an API key at [portal.hcompany.ai](https://p
 
 ## Quickstart
 
-List the agents available to your account, then launch one with a task described in plain language. Built-in agents, such as a web surfer that ships with its own browser, live under the `h/` namespace. `run_session_until_done` polls until the agent finishes and returns the final answer.
+Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `run_session_until_done` polls until the agent finishes and returns the final answer.
 
 ```python
 from hai_agents import Client, run_session_until_done
 
 client = Client(token="YOUR_API_KEY")
 
-agents = client.agents.list_agents().items
-
 result = run_session_until_done(
     client,
-    agent=agents[0].name,
+    agent="h/web-surfer-holo3-1-35b",
     messages="What are the top 3 stories on Hacker News right now?",
 )
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -35,16 +35,18 @@ Requires Python 3.10 or newer. Grab an API key at [portal.hcompany.ai](https://p
 
 ## Quickstart
 
-Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own browser, and describe the task in plain language. `run_session_until_done` polls until the agent finishes and returns the final answer.
+List the agents available to your account, then launch one with a task described in plain language. Built-in agents, such as a web surfer that ships with its own browser, live under the `h/` namespace. `run_session_until_done` polls until the agent finishes and returns the final answer.
 
 ```python
 from hai_agents import Client, run_session_until_done
 
 client = Client(token="YOUR_API_KEY")
 
+agents = client.agents.list_agents().items
+
 result = run_session_until_done(
     client,
-    agent="h/web-surfer-holo3-1-35b",
+    agent=agents[0].name,
     messages="What are the top 3 stories on Hacker News right now?",
 )
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -22,6 +22,8 @@
   &nbsp;·&nbsp;
   <a href="https://pypi.org/project/hai-agents/">PyPI</a>
   &nbsp;·&nbsp;
+  <a href="https://github.com/hcompai/hai-agents-ts">TypeScript SDK</a>
+  &nbsp;·&nbsp;
   <a href="https://hcompany.ai">H Company</a>
 </p>
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -54,15 +54,11 @@ print(result.status)  # "completed"
 print(result.answer)
 ```
 
-An `AsyncClient` mirrors this API for asyncio. Streaming progress, steering a live session, regions, structured output, and error handling are all covered in the documentation.
+An `AsyncClient` mirrors this API for asyncio.
 
 ## Documentation
 
-Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**.
-
-- [Quickstart](https://hub.hcompany.ai/agent-api/quickstart)
-- [Observe and steer a session](https://hub.hcompany.ai/agent-api/observe-and-steer)
-- [Multi-agent orchestration](https://hub.hcompany.ai/agent-api/multi-agent)
+Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**, covering streaming progress, steering a live session, regions, structured output, and error handling.
 
 ## License
 


### PR DESCRIPTION
## Summary
Pares the README down to the essentials, in the spirit of the OpenAI and Anthropic SDK READMEs.

- Keeps the banner, badges, tagline, and nav row.
- One **Install** + one **Quickstart**.
- New **Documentation** section points dynamically to the hub with a few deep links, instead of inlining steering / regions / error handling / request-limit / manual-polling sections (all already on the hub).

Applied to both the root README (GitHub homepage) and `packages/sdk/README.md` (PyPI).

Made with [Cursor](https://cursor.com)