### PR TITLE
chore(sdk): sync to agent_platform@d292cb0 (v0.1.1)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2221,7 +2221,7 @@
             },
             "type": "array",
             "title": "Environments",
-            "description": "Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At least one, at most one per kind."
+            "description": "Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At most one per kind. Required unless the agent delegates to subagents (a pure orchestrator owns none)."
           },
           "model": {
             "anyOf": [
@@ -2944,6 +2944,18 @@
             ],
             "title": "Answer Format",
             "description": "JSON Schema the final answer must conform to. Null returns a free-form text answer."
+          },
+          "agent_artifact": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Artifact",
+            "description": "Target version of the agent artifact to use."
           }
         },
         "type": "object",

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python SDK for H Company's Agent API: autonomous agents powered by Holo."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/packages/sdk/src/hai_agents/agents/client.py
+++ b/packages/sdk/src/hai_agents/agents/client.py
@@ -107,7 +107,7 @@ class AgentsClient:
             What the agent does. Parent agents read this to decide when to delegate to it.
 
         environments : typing.Sequence[AgentEnvironmentsItem]
-            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At least one, at most one per kind.
+            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At most one per kind. Required unless the agent delegates to subagents (a pure orchestrator owns none).
 
         model : typing.Optional[str]
             Model that serves the agent. Defaults to the platform model if omitted.
@@ -211,7 +211,7 @@ class AgentsClient:
             What the agent does. Parent agents read this to decide when to delegate to it.
 
         environments : typing.Sequence[AgentEnvironmentsItem]
-            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At least one, at most one per kind.
+            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At most one per kind. Required unless the agent delegates to subagents (a pure orchestrator owns none).
 
         model : typing.Optional[str]
             Model that serves the agent. Defaults to the platform model if omitted.
@@ -389,7 +389,7 @@ class AsyncAgentsClient:
             What the agent does. Parent agents read this to decide when to delegate to it.
 
         environments : typing.Sequence[AgentEnvironmentsItem]
-            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At least one, at most one per kind.
+            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At most one per kind. Required unless the agent delegates to subagents (a pure orchestrator owns none).
 
         model : typing.Optional[str]
             Model that serves the agent. Defaults to the platform model if omitted.
@@ -509,7 +509,7 @@ class AsyncAgentsClient:
             What the agent does. Parent agents read this to decide when to delegate to it.
 
         environments : typing.Sequence[AgentEnvironmentsItem]
-            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At least one, at most one per kind.
+            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At most one per kind. Required unless the agent delegates to subagents (a pure orchestrator owns none).
 
         model : typing.Optional[str]
             Model that serves the agent. Defaults to the platform model if omitted.

--- a/packages/sdk/src/hai_agents/agents/raw_client.py
+++ b/packages/sdk/src/hai_agents/agents/raw_client.py
@@ -133,7 +133,7 @@ class RawAgentsClient:
             What the agent does. Parent agents read this to decide when to delegate to it.
 
         environments : typing.Sequence[AgentEnvironmentsItem]
-            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At least one, at most one per kind.
+            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At most one per kind. Required unless the agent delegates to subagents (a pure orchestrator owns none).
 
         model : typing.Optional[str]
             Model that serves the agent. Defaults to the platform model if omitted.
@@ -291,7 +291,7 @@ class RawAgentsClient:
             What the agent does. Parent agents read this to decide when to delegate to it.
 
         environments : typing.Sequence[AgentEnvironmentsItem]
-            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At least one, at most one per kind.
+            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At most one per kind. Required unless the agent delegates to subagents (a pure orchestrator owns none).
 
         model : typing.Optional[str]
             Model that serves the agent. Defaults to the platform model if omitted.
@@ -523,7 +523,7 @@ class AsyncRawAgentsClient:
             What the agent does. Parent agents read this to decide when to delegate to it.
 
         environments : typing.Sequence[AgentEnvironmentsItem]
-            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At least one, at most one per kind.
+            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At most one per kind. Required unless the agent delegates to subagents (a pure orchestrator owns none).
 
         model : typing.Optional[str]
             Model that serves the agent. Defaults to the platform model if omitted.
@@ -681,7 +681,7 @@ class AsyncRawAgentsClient:
             What the agent does. Parent agents read this to decide when to delegate to it.
 
         environments : typing.Sequence[AgentEnvironmentsItem]
-            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At least one, at most one per kind.
+            Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At most one per kind. Required unless the agent delegates to subagents (a pure orchestrator owns none).
 
         model : typing.Optional[str]
             Model that serves the agent. Defaults to the platform model if omitted.

--- a/packages/sdk/src/hai_agents/sessions/client.py
+++ b/packages/sdk/src/hai_agents/sessions/client.py
@@ -140,6 +140,7 @@ class SessionsClient:
         group_id: typing.Optional[str] = OMIT,
         parent_session_id: typing.Optional[str] = OMIT,
         answer_format: typing.Optional[typing.Dict[str, typing.Any]] = OMIT,
+        agent_artifact: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> Session:
         """
@@ -176,6 +177,9 @@ class SessionsClient:
         answer_format : typing.Optional[typing.Dict[str, typing.Any]]
             JSON Schema the final answer must conform to. Null returns a free-form text answer.
 
+        agent_artifact : typing.Optional[str]
+            Target version of the agent artifact to use.
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -205,6 +209,7 @@ class SessionsClient:
             group_id=group_id,
             parent_session_id=parent_session_id,
             answer_format=answer_format,
+            agent_artifact=agent_artifact,
             request_options=request_options,
         )
         return _response.data
@@ -866,6 +871,7 @@ class AsyncSessionsClient:
         group_id: typing.Optional[str] = OMIT,
         parent_session_id: typing.Optional[str] = OMIT,
         answer_format: typing.Optional[typing.Dict[str, typing.Any]] = OMIT,
+        agent_artifact: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> Session:
         """
@@ -901,6 +907,9 @@ class AsyncSessionsClient:
 
         answer_format : typing.Optional[typing.Dict[str, typing.Any]]
             JSON Schema the final answer must conform to. Null returns a free-form text answer.
+
+        agent_artifact : typing.Optional[str]
+            Target version of the agent artifact to use.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -939,6 +948,7 @@ class AsyncSessionsClient:
             group_id=group_id,
             parent_session_id=parent_session_id,
             answer_format=answer_format,
+            agent_artifact=agent_artifact,
             request_options=request_options,
         )
         return _response.data

--- a/packages/sdk/src/hai_agents/sessions/raw_client.py
+++ b/packages/sdk/src/hai_agents/sessions/raw_client.py
@@ -162,6 +162,7 @@ class RawSessionsClient:
         group_id: typing.Optional[str] = OMIT,
         parent_session_id: typing.Optional[str] = OMIT,
         answer_format: typing.Optional[typing.Dict[str, typing.Any]] = OMIT,
+        agent_artifact: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[Session]:
         """
@@ -198,6 +199,9 @@ class RawSessionsClient:
         answer_format : typing.Optional[typing.Dict[str, typing.Any]]
             JSON Schema the final answer must conform to. Null returns a free-form text answer.
 
+        agent_artifact : typing.Optional[str]
+            Target version of the agent artifact to use.
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -222,6 +226,7 @@ class RawSessionsClient:
                 "group_id": group_id,
                 "parent_session_id": parent_session_id,
                 "answer_format": answer_format,
+                "agent_artifact": agent_artifact,
             },
             headers={
                 "content-type": "application/json",
@@ -1199,6 +1204,7 @@ class AsyncRawSessionsClient:
         group_id: typing.Optional[str] = OMIT,
         parent_session_id: typing.Optional[str] = OMIT,
         answer_format: typing.Optional[typing.Dict[str, typing.Any]] = OMIT,
+        agent_artifact: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[Session]:
         """
@@ -1235,6 +1241,9 @@ class AsyncRawSessionsClient:
         answer_format : typing.Optional[typing.Dict[str, typing.Any]]
             JSON Schema the final answer must conform to. Null returns a free-form text answer.
 
+        agent_artifact : typing.Optional[str]
+            Target version of the agent artifact to use.
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -1259,6 +1268,7 @@ class AsyncRawSessionsClient:
                 "group_id": group_id,
                 "parent_session_id": parent_session_id,
                 "answer_format": answer_format,
+                "agent_artifact": agent_artifact,
             },
             headers={
                 "content-type": "application/json",

--- a/packages/sdk/src/hai_agents/types/agent.py
+++ b/packages/sdk/src/hai_agents/types/agent.py
@@ -27,7 +27,7 @@ class Agent(UniversalBaseModel):
 
     environments: typing.List[AgentEnvironmentsItem] = pydantic.Field()
     """
-    Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At least one, at most one per kind.
+    Environments the agent runs in. Each entry is a registered environment's id or an inline definition. At most one per kind. Required unless the agent delegates to subagents (a pure orchestrator owns none).
     """
 
     model: typing.Optional[str] = pydantic.Field(default=None)

--- a/packages/sdk/src/hai_agents/types/session_request.py
+++ b/packages/sdk/src/hai_agents/types/session_request.py
@@ -55,6 +55,11 @@ class SessionRequest(UniversalBaseModel):
     JSON Schema the final answer must conform to. Null returns a free-form text answer.
     """
 
+    agent_artifact: typing.Optional[str] = pydantic.Field(default=None)
+    """
+    Target version of the agent artifact to use.
+    """
+
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
     else:


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.1.1` (patch — additive change)
**Upstream:** agent_platform@d292cb0
