### PR TITLE
chore(sdk): sync to agent_platform@35efd9b (v0.2.0)

### DIFF
--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "0.1.1"
+version = "0.2.0"
 description = "Python SDK for H Company's Agent API: autonomous agents powered by Holo."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/packages/sdk/src/hai_agents/agents/client.py
+++ b/packages/sdk/src/hai_agents/agents/client.py
@@ -74,7 +74,7 @@ class AgentsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.agents.list_agents()
         """
@@ -134,7 +134,7 @@ class AgentsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.agents.create_agent(
             name="name",
@@ -175,7 +175,7 @@ class AgentsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.agents.get_agent(
             agent_name="agent_name",
@@ -238,7 +238,7 @@ class AgentsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.agents.update_agent(
             agent_name="agent_name",
@@ -280,7 +280,7 @@ class AgentsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.agents.delete_agent(
             agent_name="agent_name",
@@ -350,7 +350,7 @@ class AsyncAgentsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -418,7 +418,7 @@ class AsyncAgentsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -467,7 +467,7 @@ class AsyncAgentsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -538,7 +538,7 @@ class AsyncAgentsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -588,7 +588,7 @@ class AsyncAgentsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 

--- a/packages/sdk/src/hai_agents/client.py
+++ b/packages/sdk/src/hai_agents/client.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import os
 import typing
 
 import httpx
+from .core.api_error import ApiError
 from .core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
 from .core.logging import LogConfig, Logger
 from .environment import HaiAgentsEnvironment
@@ -34,7 +36,7 @@ class Client:
 
 
 
-    token : typing.Union[str, typing.Callable[[], str]]
+    api_key : typing.Optional[typing.Union[str, typing.Callable[[], str]]]
     headers : typing.Optional[typing.Dict[str, str]]
         Additional headers to send with every request.
 
@@ -58,7 +60,7 @@ class Client:
     from hai_agents import Client
 
     client = Client(
-        token="YOUR_TOKEN",
+        api_key="YOUR_API_KEY",
     )
     """
 
@@ -67,7 +69,7 @@ class Client:
         *,
         base_url: typing.Optional[str] = None,
         environment: HaiAgentsEnvironment = HaiAgentsEnvironment.EU,
-        token: typing.Union[str, typing.Callable[[], str]],
+        api_key: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("H_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -79,9 +81,11 @@ class Client:
             timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
         )
         _defaulted_max_retries = max_retries if max_retries is not None else 2
+        if api_key is None:
+            raise ApiError(body="The client must be instantiated be either passing in api_key or setting H_API_KEY")
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
-            token=token,
+            api_key=api_key,
             headers=headers,
             httpx_client=httpx_client
             if httpx_client is not None
@@ -166,7 +170,7 @@ class AsyncClient:
 
 
 
-    token : typing.Union[str, typing.Callable[[], str]]
+    api_key : typing.Optional[typing.Union[str, typing.Callable[[], str]]]
     headers : typing.Optional[typing.Dict[str, str]]
         Additional headers to send with every request.
 
@@ -193,7 +197,7 @@ class AsyncClient:
     from hai_agents import AsyncClient
 
     client = AsyncClient(
-        token="YOUR_TOKEN",
+        api_key="YOUR_API_KEY",
     )
     """
 
@@ -202,7 +206,7 @@ class AsyncClient:
         *,
         base_url: typing.Optional[str] = None,
         environment: HaiAgentsEnvironment = HaiAgentsEnvironment.EU,
-        token: typing.Union[str, typing.Callable[[], str]],
+        api_key: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("H_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         async_token: typing.Optional[typing.Callable[[], typing.Awaitable[str]]] = None,
         timeout: typing.Optional[float] = None,
@@ -215,9 +219,11 @@ class AsyncClient:
             timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
         )
         _defaulted_max_retries = max_retries if max_retries is not None else 2
+        if api_key is None:
+            raise ApiError(body="The client must be instantiated be either passing in api_key or setting H_API_KEY")
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
-            token=token,
+            api_key=api_key,
             headers=headers,
             async_token=async_token,
             httpx_client=httpx_client

--- a/packages/sdk/src/hai_agents/core/client_wrapper.py
+++ b/packages/sdk/src/hai_agents/core/client_wrapper.py
@@ -11,14 +11,14 @@ class BaseClientWrapper:
     def __init__(
         self,
         *,
-        token: typing.Union[str, typing.Callable[[], str]],
+        api_key: typing.Union[str, typing.Callable[[], str]],
         headers: typing.Optional[typing.Dict[str, str]] = None,
         base_url: str,
         timeout: typing.Optional[float] = None,
         max_retries: int = 2,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        self._token = token
+        self._api_key = api_key
         self._headers = headers
         self._base_url = base_url
         self._timeout = timeout
@@ -29,14 +29,14 @@ class BaseClientWrapper:
         headers: typing.Dict[str, str] = {
             **(self.get_custom_headers() or {}),
         }
-        headers["Authorization"] = f"Bearer {self._get_token()}"
+        headers["Authorization"] = f"Bearer {self._get_api_key()}"
         return headers
 
-    def _get_token(self) -> str:
-        if isinstance(self._token, str):
-            return self._token
+    def _get_api_key(self) -> str:
+        if isinstance(self._api_key, str):
+            return self._api_key
         else:
-            return self._token()
+            return self._api_key()
 
     def get_custom_headers(self) -> typing.Optional[typing.Dict[str, str]]:
         return self._headers
@@ -55,7 +55,7 @@ class SyncClientWrapper(BaseClientWrapper):
     def __init__(
         self,
         *,
-        token: typing.Union[str, typing.Callable[[], str]],
+        api_key: typing.Union[str, typing.Callable[[], str]],
         headers: typing.Optional[typing.Dict[str, str]] = None,
         base_url: str,
         timeout: typing.Optional[float] = None,
@@ -64,7 +64,12 @@ class SyncClientWrapper(BaseClientWrapper):
         httpx_client: httpx.Client,
     ):
         super().__init__(
-            token=token, headers=headers, base_url=base_url, timeout=timeout, max_retries=max_retries, logging=logging
+            api_key=api_key,
+            headers=headers,
+            base_url=base_url,
+            timeout=timeout,
+            max_retries=max_retries,
+            logging=logging,
         )
         self.httpx_client = HttpClient(
             httpx_client=httpx_client,
@@ -80,7 +85,7 @@ class AsyncClientWrapper(BaseClientWrapper):
     def __init__(
         self,
         *,
-        token: typing.Union[str, typing.Callable[[], str]],
+        api_key: typing.Union[str, typing.Callable[[], str]],
         headers: typing.Optional[typing.Dict[str, str]] = None,
         base_url: str,
         timeout: typing.Optional[float] = None,
@@ -90,7 +95,12 @@ class AsyncClientWrapper(BaseClientWrapper):
         httpx_client: httpx.AsyncClient,
     ):
         super().__init__(
-            token=token, headers=headers, base_url=base_url, timeout=timeout, max_retries=max_retries, logging=logging
+            api_key=api_key,
+            headers=headers,
+            base_url=base_url,
+            timeout=timeout,
+            max_retries=max_retries,
+            logging=logging,
         )
         self._async_token = async_token
         self.httpx_client = AsyncHttpClient(

--- a/packages/sdk/src/hai_agents/environments/client.py
+++ b/packages/sdk/src/hai_agents/environments/client.py
@@ -78,7 +78,7 @@ class EnvironmentsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.environments.list_environments()
         """
@@ -111,7 +111,7 @@ class EnvironmentsClient:
         from hai_agents.environments import CreateEnvironmentRequest_Web
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.environments.create_environment(
             request=CreateEnvironmentRequest_Web(
@@ -146,7 +146,7 @@ class EnvironmentsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.environments.get_environment(
             id="id",
@@ -181,7 +181,7 @@ class EnvironmentsClient:
         from hai_agents.environments import UpdateEnvironmentRequestBody_Web
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.environments.update_environment(
             id="id",
@@ -216,7 +216,7 @@ class EnvironmentsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.environments.delete_environment(
             id="id",
@@ -290,7 +290,7 @@ class AsyncEnvironmentsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -331,7 +331,7 @@ class AsyncEnvironmentsClient:
         from hai_agents.environments import CreateEnvironmentRequest_Web
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -374,7 +374,7 @@ class AsyncEnvironmentsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -417,7 +417,7 @@ class AsyncEnvironmentsClient:
         from hai_agents.environments import UpdateEnvironmentRequestBody_Web
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -460,7 +460,7 @@ class AsyncEnvironmentsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 

--- a/packages/sdk/src/hai_agents/sessions/client.py
+++ b/packages/sdk/src/hai_agents/sessions/client.py
@@ -106,7 +106,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.list_sessions()
         """
@@ -193,7 +193,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.create_session(
             agent="agent",
@@ -233,7 +233,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.get_session_quota()
         """
@@ -261,7 +261,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.get_session(
             id="id",
@@ -290,7 +290,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.cancel_session(
             id="id",
@@ -320,7 +320,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.get_session_status(
             id="id",
@@ -358,7 +358,7 @@ class SessionsClient:
         from hai_agents.sessions import SendSessionMessagesRequestBody_UserMessage
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.send_session_messages(
             id="id",
@@ -391,7 +391,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.pause_session(
             id="id",
@@ -420,7 +420,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.resume_session(
             id="id",
@@ -449,7 +449,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.force_session_answer(
             id="id",
@@ -496,7 +496,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.get_session_changes(
             id="id",
@@ -550,7 +550,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.list_session_events(
             id="id",
@@ -592,7 +592,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.submit_session_feedback(
             id="id",
@@ -638,7 +638,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.submit_event_feedback(
             id="id",
@@ -672,7 +672,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.share_session(
             id="id",
@@ -701,7 +701,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.unshare_session(
             id="id",
@@ -736,7 +736,7 @@ class SessionsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.sessions.get_session_resource(
             id="id",
@@ -831,7 +831,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -926,7 +926,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -974,7 +974,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1010,7 +1010,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1047,7 +1047,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1087,7 +1087,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1133,7 +1133,7 @@ class AsyncSessionsClient:
         from hai_agents.sessions import SendSessionMessagesRequestBody_UserMessage
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1174,7 +1174,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1211,7 +1211,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1248,7 +1248,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1303,7 +1303,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1365,7 +1365,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1415,7 +1415,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1469,7 +1469,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1511,7 +1511,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1548,7 +1548,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -1591,7 +1591,7 @@ class AsyncSessionsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 

--- a/packages/sdk/src/hai_agents/skills/client.py
+++ b/packages/sdk/src/hai_agents/skills/client.py
@@ -71,7 +71,7 @@ class SkillsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.skills.list_skills()
         """
@@ -123,7 +123,7 @@ class SkillsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.skills.create_skill(
             name="name",
@@ -162,7 +162,7 @@ class SkillsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.skills.get_skill(
             name="name",
@@ -217,7 +217,7 @@ class SkillsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.skills.update_skill(
             name_="name",
@@ -257,7 +257,7 @@ class SkillsClient:
         from hai_agents import Client
 
         client = Client(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
         client.skills.delete_skill(
             name="name",
@@ -327,7 +327,7 @@ class AsyncSkillsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -387,7 +387,7 @@ class AsyncSkillsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -434,7 +434,7 @@ class AsyncSkillsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -497,7 +497,7 @@ class AsyncSkillsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 
@@ -545,7 +545,7 @@ class AsyncSkillsClient:
         from hai_agents import AsyncClient
 
         client = AsyncClient(
-            token="YOUR_TOKEN",
+            api_key="YOUR_API_KEY",
         )
 
 


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.2.0` (minor — breaking upstream change)
**Upstream:** agent_platform@35efd9b
