### PR TITLE
docs: simplify quickstart to export H_API_KEY + bare Client()

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@
 pip install hai-agents
 ```
 
-Requires Python 3.10 or newer. Grab an API key at [portal.hcompany.ai](https://portal.hcompany.ai).
+Requires Python 3.10 or newer. Grab an API key at [portal.hcompany.ai](https://portal.hcompany.ai) and export it:
+
+```bash
+export H_API_KEY=hk-...
+```
 
 ## Quickstart
 
@@ -42,7 +46,7 @@ Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own b
 ```python
 from hai_agents import Client, run_session
 
-client = Client(api_key="YOUR_API_KEY")  # or set H_API_KEY in the environment and call Client()
+client = Client()  # reads H_API_KEY from the environment
 
 result = run_session(
     client,


### PR DESCRIPTION
Follow-up polish to #59. The client reads `H_API_KEY` from the environment, so the quickstart now exports the key (`hk-...`) and constructs a bare `Client()` instead of passing `api_key` inline. Mirrors the TS change in hcompai/hai-agents-ts#49.

Made with [Cursor](https://cursor.com)