### PR TITLE
chore: sync uv.lock hai-agents version to 0.1.3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -66,7 +66,7 @@ wheels = [
 
 [[package]]
 name = "hai-agents"
-version = "0.1.1"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
The auto-sync workflow bumps `pyproject.toml` on every sync but leaves the `hai-agents` entry in `uv.lock` untouched, so the lock drifted to `0.1.1` while `pyproject.toml` is `0.1.3`. This realigns the lock per the release runbook ("set pyproject.toml **and** the hai-agents entry in uv.lock to the new version").

Not release-blocking (the wheel/sdist build from `pyproject.toml`, and `test.yaml` installs via `pip install -e .`), but keeps `uv lock --check` honest.

Root cause is upstream: `agent_platform`'s `generate-sdks.yaml` version-bump step should also bump `uv.lock`. Worth a follow-up there so this stops recurring.

Made with [Cursor](https://cursor.com)