### PR TITLE
Add `hai install`: auto-wire the MCP server into coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ Example MCP client configuration:
 The MCP server exposes tools to run an agent task, list available agents, inspect
 sessions, send follow-up messages, cancel sessions, and create share URLs.
 
+### Plug into your coding agent
+
+`hai install` wires the MCP server into MCP hosts on your machine. It merges the
+server into each host's config (preserving anything already there) and, for hosts
+that support Agent Skills, drops in a skill that teaches the host when to delegate
+to H agents.
+
+```bash
+hai install            # wire every detected host
+hai install cursor     # wire one host
+hai install list       # show supported hosts and which are detected
+hai uninstall          # remove from detected hosts
+```
+
+Supported hosts: Cursor, Claude Code, Claude Desktop, Codex, GitHub Copilot CLI,
+OpenCode, and Antigravity. Requires the `mcp` extra so `hai-mcp` is on your PATH.
+
 ## Documentation
 
 Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**, covering streaming progress, steering a live session, regions, structured output, and error handling.

--- a/src/hai_agents_cli/app.py
+++ b/src/hai_agents_cli/app.py
@@ -21,6 +21,17 @@ from hai_agents_common.credentials import absolute_share_url, make_client
 from hai_agents_common.jsonable import to_jsonable
 
 from . import auth
+from .hosts import (
+    CLIENTS,
+    Status,
+    host_present,
+    host_target,
+    unwire_mcp,
+    unwire_skill,
+    wire_mcp,
+    wire_skill,
+)
+from .hosts import Client as HostClient
 
 H_GLYPH = "\n".join(
     (
@@ -224,6 +235,80 @@ def share(ctx: typer.Context, session_id: str = typer.Argument(...)) -> None:
         _print_json({"share_url": share_url})
     else:
         print(share_url)
+
+
+_STATUS_STYLE: dict[Status, tuple[str, str]] = {
+    Status.INSTALLED: ("[bold green]+[/bold green]", "dim"),
+    Status.REMOVED: ("[bold green]-[/bold green]", "dim"),
+    Status.SKIPPED: ("[dim green].[/dim green]", "dim"),
+    Status.ABSENT: ("[yellow]o[/yellow]", "yellow"),
+    Status.FAILED: ("[bold red]x[/bold red]", "red"),
+}
+_ID_WIDTH = max(len(host_id) for host_id in CLIENTS)
+
+
+@app.command()
+def install(
+    host: str = typer.Argument(None, help="Host id, 'list' to enumerate, or omit to wire all detected."),
+) -> None:
+    """Wire the hai MCP server (and a delegation skill) into MCP hosts like Cursor or Claude Code."""
+    if host == "list":
+        _list_hosts()
+        return
+    _apply_hosts(host, wire_mcp, wire_skill, verb="install")
+
+
+@app.command()
+def uninstall(
+    host: str = typer.Argument(None, help="Host id, or omit to remove from all detected."),
+) -> None:
+    """Remove the hai MCP server and delegation skill from MCP hosts."""
+    _apply_hosts(host, unwire_mcp, unwire_skill, verb="uninstall")
+
+
+def _list_hosts() -> None:
+    console.print()
+    for host_id, c in CLIENTS.items():
+        glyph = "[green]+[/green]" if host_present(c) else "[dim].[/dim]"
+        console.print(f"  {glyph} [bold cyan]{host_id:<{_ID_WIDTH}}[/bold cyan]  [dim]{host_target(c)}[/dim]")
+    console.print("\n  [dim]+ = detected; wire with[/dim] [cyan]hai install <id>[/cyan]\n")
+
+
+def _resolve_targets(host: str | None) -> list[tuple[str, HostClient]]:
+    if host is None:
+        targets = [(host_id, c) for host_id, c in CLIENTS.items() if host_present(c)]
+        if not targets:
+            err_console.print("[yellow]No supported hosts detected.[/yellow] Try [cyan]hai install list[/cyan].")
+            raise typer.Exit(1)
+        return targets
+    if host in CLIENTS:
+        return [(host, CLIENTS[host])]
+    err_console.print(f"[red]Error:[/red] unknown host {host!r}. Try [cyan]hai install list[/cyan].")
+    raise typer.Exit(2)
+
+
+def _apply_hosts(host: str | None, mcp_fn, skill_fn, verb: str) -> None:
+    targets = _resolve_targets(host)
+    console.print()
+    failed = False
+    for host_id, c in targets:
+        status, detail = mcp_fn(c)
+        glyph, color = _STATUS_STYLE[status]
+        line = f"  {glyph} [bold cyan]{host_id:<{_ID_WIDTH}}[/bold cyan]  [{color}]{detail}[/{color}]"
+        skill_fatal = False
+        if c.skills_dir is not None:
+            s_status, s_detail = skill_fn(c)
+            skill_fatal = s_status.fatal
+            if s_status.ok:
+                line += f"  [dim]-> {s_detail}[/dim]"
+            else:
+                s_glyph, s_color = _STATUS_STYLE[s_status]
+                line += f"  {s_glyph} [{s_color}]{s_detail}[/{s_color}]"
+        console.print(line)
+        failed |= status.fatal or skill_fatal
+    console.print()
+    if failed:
+        raise typer.Exit(1)
 
 
 app.add_typer(sessions_app, name="sessions")

--- a/src/hai_agents_cli/host_skills/hai-agents/SKILL.md
+++ b/src/hai_agents_cli/host_skills/hai-agents/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: hai-agents
+description: Run H Company's hosted browser and computer-use agents through the Agent API. Use the run_agent tool when a task needs a real browser on the open web (navigating sites, filling forms, clicking through flows, scraping content that only appears after interaction, or multi-step research a static search cannot answer). Other tools (list_agents, get_session, send_message, cancel_session, share_session) discover agents and inspect or steer a run by session id.
+---
+
+# H Agents (Agent API)
+
+These tools call H Company's cloud agents over the Agent API. The credential is read from `HAI_API_KEY` (process env or `~/.config/hai/.env`); if calls fail with an auth error, the user needs to run `hai login`.
+
+## Tools
+
+### `run_agent(task, agent?, max_steps?, max_time_s?) -> {session_id, status, answer}`
+The main tool. Creates a session, runs the agent to a terminal state, and returns. Blocking.
+- `task` (str, required): the full instruction for the agent. See "Writing the task" below.
+- `agent` (str, default `h/web-surfer-holo3-1-35b`): registered agent name. Get others from `list_agents`.
+- `max_steps` (int, default `20`): cap on reasoning/action steps before the run stops.
+- `max_time_s` (float, default `180.0`): backend wall-clock budget in seconds.
+- Returns: `session_id` (use it with the other tools), `status` (terminal state, e.g. completed/failed/cancelled), `answer` (the agent's final text, or null if none).
+
+Raise `max_steps`/`max_time_s` for harder, multi-page tasks; the defaults suit a quick lookup.
+
+### `list_agents(search?, page?, size?) -> page of agent definitions`
+Discover available agents. `search` (str, optional) case-insensitively matches name/description; `page` (int, default 1), `size` (int, default 20). Use a returned name as `run_agent`'s `agent`.
+
+### `get_session(session_id) -> session envelope`
+Fetch the full state/trajectory of a session by id. Use to inspect what an agent did.
+
+### `send_message(session_id, message) -> {ack: true}`
+Add a follow-up user message to an existing session. Use to steer or extend a run instead of starting a fresh one. Note `run_agent` already blocks to completion, so follow-ups are for continuing a finished session or correcting course.
+
+### `cancel_session(session_id) -> {ack: true}`
+Stop a session. Use if a run is going the wrong way or is no longer needed.
+
+### `share_session(session_id) -> {share_url}`
+Produce a public URL to the session's trajectory. Surface it to the user so they can watch what the agent did.
+
+## When to use run_agent
+
+Use it when the answer lives behind real web interaction: browsing specific sites, comparing live data across pages, filling or submitting forms, navigating multi-step flows, or scraping content that only renders after clicking. Also for open-ended web research where the path isn't known up front and one search query won't do.
+
+Do not use it when a plain web search or your own knowledge already answers the question, when the work is local file/shell/code editing, or when the user wants something written or reasoned about in the conversation rather than fetched from the live web.
+
+## Writing the task
+
+The agent is blind to you. It does not see this conversation, your other tool results, or earlier `run_agent` calls. Everything it needs has to live in the `task` string: the goal, any starting URL or search to run, constraints (read-only vs. submit, how many results, date ranges), and the exact return shape you want (a number, a list, JSON, a short summary). If you want structured output, say so in the task.
+
+Passing the user's message verbatim is usually the wrong reflex: their wording elides what they expect you to carry (which site, which account, what they already told you, what the answer should look like). Fold that context in. But preserve concrete details the user supplied (specific URLs, names, search terms, exact quotes), since the agent grounds on them. Add context; don't reword.
+
+Treat a run as long-running and fallible. The agent returns whatever partial result it has if it exhausts `max_steps`/`max_time_s`, and runs can fail (a site blocks automation, an element isn't found, a login wall). Don't surface a final answer to the user while a run is in flight. On a weak or failed result, tighten the task (exact URL, clearer success criterion) and retry, or raise the budgets, or report the blocker. For anything that mutates real state on a logged-in site (posting, purchasing, deleting), confirm with the user first or reframe the task as observe-and-report.
+
+## Examples
+
+Each shows a casual user message becoming a self-contained `task`.
+
+User: *"what's the cheapest direct flight London to NYC next friday"*
+
+    run_agent
+      task: On Google Flights, find the cheapest nonstop economy flight from London (any London airport) to New York City (any NYC airport) departing next Friday. Report airline, price in GBP, and exact departure/arrival times. Read-only; do not book. Return as JSON.
+      max_time_s: 300
+
+User: *"summarize what this company does"* (with a URL in the thread)
+
+    run_agent
+      task: Open https://example-startup.com, read the homepage, product, and about pages, and summarize in 3 sentences what the company sells, who the customer is, and how it's priced. If pricing isn't public, say so.
+
+User (after you drafted a shortlist): *"which of these are still hiring backend engineers"*
+
+    run_agent
+      task: |
+        For each company below, open its careers page and report whether it currently lists an open backend/server-side engineering role (yes/no, plus title and location if yes). Return a JSON array keyed by company.
+
+        <the shortlist you just produced>
+
+The last example is load-bearing: you already did the reasoning and hand the agent only the live-web part.

--- a/src/hai_agents_cli/hosts.py
+++ b/src/hai_agents_cli/hosts.py
@@ -1,0 +1,323 @@
+"""MCP host registry + install/uninstall dispatch + skill auto-wire. Add a host = add one `Client`."""
+
+from __future__ import annotations
+
+import enum
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SERVER_KEY = "hai"
+MCP_BINARY = "hai-mcp"
+SKILL_NAME = "hai-agents"
+
+
+class Status(enum.Enum):
+    """Outcome of one install/uninstall step."""
+
+    INSTALLED = "installed"
+    REMOVED = "removed"
+    SKIPPED = "skipped"
+    ABSENT = "absent"
+    FAILED = "failed"
+
+    @property
+    def ok(self) -> bool:
+        return self in (Status.INSTALLED, Status.REMOVED, Status.SKIPPED)
+
+    @property
+    def fatal(self) -> bool:
+        return self is Status.FAILED
+
+
+def home_short(p: Path | str) -> str:
+    """Render `p` with $HOME collapsed to `~`."""
+    s = str(p)
+    home = str(Path.home())
+    return "~" + s[len(home) :] if s.startswith(home) else s
+
+
+def resolve_mcp_command() -> str:
+    """Absolute path to `hai-mcp`, baked into host configs so GUI hosts hit it even with a stripped PATH."""
+    venv_bin = str(Path(sys.executable).parent)
+    found = shutil.which(MCP_BINARY, path=venv_bin) or shutil.which(MCP_BINARY)
+    if not found:
+        raise RuntimeError(
+            f"Cannot resolve {MCP_BINARY!r} on this machine. "
+            f"Install with `pip install 'hai-agents[mcp]'` (or `uv tool install 'hai-agents[mcp]'`), then re-run."
+        )
+    return os.path.realpath(found)
+
+
+MCP_LEAF: dict[str, Any] = {"command": MCP_BINARY}
+
+
+@dataclass(frozen=True)
+class Client:
+    """One MCP host: CLI hosts set `cli_add`/`cli_remove`; file hosts set `config_path` + `key_path` + `leaf`."""
+
+    name: str
+    config_path: str | None = None
+    cli_add: tuple[str, ...] | None = None
+    cli_remove: tuple[str, ...] | None = None
+    key_path: tuple[str, ...] | None = None
+    leaf: dict[str, Any] | None = None
+    skills_dir: str | None = None
+    home_marker: str | None = None
+
+
+def _claude_desktop_config_path() -> str:
+    """Per-OS Claude Desktop config path."""
+    system = platform.system()
+    if system == "Windows":
+        appdata = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return str(Path(appdata) / "Claude" / "claude_desktop_config.json")
+    if system == "Darwin":
+        return "~/Library/Application Support/Claude/claude_desktop_config.json"
+    xdg = os.environ.get("XDG_CONFIG_HOME") or "~/.config"
+    return f"{xdg}/Claude/claude_desktop_config.json"
+
+
+CLIENTS: dict[str, Client] = {
+    "antigravity": Client(
+        name="Antigravity (Google)",
+        config_path="~/.gemini/config/mcp_config.json",
+        key_path=("mcpServers", SERVER_KEY),
+        leaf=MCP_LEAF,
+    ),
+    "claude-code": Client(
+        name="Claude Code",
+        cli_add=("claude", "mcp", "add", "--transport", "stdio", SERVER_KEY, "--", MCP_BINARY),
+        cli_remove=("claude", "mcp", "remove", SERVER_KEY),
+        skills_dir=".claude/skills",
+        home_marker=".claude",
+    ),
+    "claude-desktop": Client(
+        name="Claude Desktop",
+        config_path=_claude_desktop_config_path(),
+        key_path=("mcpServers", SERVER_KEY),
+        leaf=MCP_LEAF,
+    ),
+    "codex": Client(
+        name="Codex (OpenAI)",
+        cli_add=("codex", "mcp", "add", SERVER_KEY, "--", MCP_BINARY),
+        cli_remove=("codex", "mcp", "remove", SERVER_KEY),
+        skills_dir=".agents/skills",
+        home_marker=".codex",
+    ),
+    "copilot": Client(
+        name="GitHub Copilot CLI",
+        config_path="~/.copilot/mcp-config.json",
+        key_path=("mcpServers", SERVER_KEY),
+        leaf={"type": "local", "command": MCP_BINARY, "tools": ["*"]},
+    ),
+    "cursor": Client(
+        name="Cursor",
+        config_path="~/.cursor/mcp.json",
+        key_path=("mcpServers", SERVER_KEY),
+        leaf={"type": "stdio", "command": MCP_BINARY},
+    ),
+    "opencode": Client(
+        name="OpenCode",
+        config_path="~/.config/opencode/opencode.json",
+        key_path=("mcp", SERVER_KEY),
+        leaf={"type": "local", "command": [MCP_BINARY], "enabled": True},
+        skills_dir=".config/opencode/skills",
+        home_marker=".config/opencode",
+    ),
+}
+
+
+def host_present(c: Client) -> bool:
+    """True if the host looks installed under $HOME."""
+    home = Path.home()
+    if c.home_marker and (home / c.home_marker).exists():
+        return True
+    return bool(c.config_path and Path(c.config_path).expanduser().parent.exists())
+
+
+def host_target(c: Client) -> str:
+    """Where our config lands for this host (~-path, or 'via CLI')."""
+    return home_short(c.config_path) if c.config_path else "via CLI"
+
+
+def _materialize_leaf(leaf: dict[str, Any]) -> dict[str, Any]:
+    """Substitute the `hai-mcp` placeholder in `command`/`args` with its absolute path."""
+    mcp = resolve_mcp_command()
+    out: dict[str, Any] = dict(leaf)
+    for k, v in list(out.items()):
+        if k == "command" and isinstance(v, str) and v == MCP_BINARY:
+            out[k] = mcp
+        elif k in ("command", "args") and isinstance(v, list):
+            out[k] = [mcp if a == MCP_BINARY else a for a in v]
+    return out
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Write+fsync to a sibling temp then `rename` over the target. Crash-safe."""
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def _load_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not (path.exists() and path.stat().st_size > 0):
+        return {}, None
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, f"{home_short(path)}: invalid JSON ({exc})"
+    if not isinstance(loaded, dict):
+        return None, f"{home_short(path)}: top-level is not an object"
+    return loaded, None
+
+
+def _run_cli(cmd: tuple[str, ...], already_substrings: tuple[str, ...]) -> tuple[Status, str]:
+    exe = shutil.which(cmd[0])
+    if exe is None:
+        return Status.ABSENT, f"{cmd[0]!r} not on PATH"
+    resolved = [exe, *cmd[1:]]
+    # Before `--` is the host's server label (stays bare); after, the binary must be absolute.
+    try:
+        sep = resolved.index("--")
+    except ValueError:
+        sep = len(resolved)
+    mcp = resolve_mcp_command()
+    resolved = resolved[:sep] + [mcp if a == MCP_BINARY else a for a in resolved[sep:]]
+    try:
+        subprocess.run(resolved, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        msg = (exc.stderr or exc.stdout or str(exc)).strip()
+        if any(s in msg.lower() for s in already_substrings):
+            return Status.SKIPPED, f"{cmd[0]} already up to date"
+        return Status.FAILED, msg
+    return Status.INSTALLED, f"via {cmd[0]} CLI"
+
+
+def wire_mcp(c: Client) -> tuple[Status, str]:
+    """Add our MCP server to host `c`: CLI add or JSON deep-merge."""
+    if c.cli_add is not None:
+        return _run_cli(c.cli_add, already_substrings=("already",))
+    assert c.config_path is not None and c.key_path is not None and c.leaf is not None
+    path = Path(c.config_path).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data, error = _load_json(path)
+    if data is None:
+        return Status.FAILED, error or "invalid config"
+    cursor: Any = data
+    for k in c.key_path[:-1]:
+        cursor = cursor.setdefault(k, {})
+        if not isinstance(cursor, dict):
+            return Status.FAILED, f"{home_short(path)}: {k!r} is not an object"
+    last = c.key_path[-1]
+    existing = cursor.get(last)
+    leaf = _materialize_leaf(c.leaf)
+    merged = {**existing, **leaf} if isinstance(existing, dict) else leaf
+    if existing == merged:
+        return Status.SKIPPED, home_short(path)
+    cursor[last] = merged
+    _atomic_write_text(path, json.dumps(data, indent=2) + "\n")
+    return Status.INSTALLED, home_short(path)
+
+
+def unwire_mcp(c: Client) -> tuple[Status, str]:
+    """Remove our MCP server from host `c`: CLI remove or drop the JSON leaf."""
+    if c.cli_remove is not None:
+        return _run_cli(c.cli_remove, already_substrings=("no", "not found", "does not"))
+    assert c.config_path is not None and c.key_path is not None
+    path = Path(c.config_path).expanduser()
+    if not path.exists():
+        return Status.SKIPPED, "not configured"
+    data, error = _load_json(path)
+    if data is None:
+        return Status.FAILED, error or "invalid config"
+    cursor: Any = data
+    for k in c.key_path[:-1]:
+        nxt = cursor.get(k) if isinstance(cursor, dict) else None
+        if not isinstance(nxt, dict):
+            return Status.SKIPPED, "not configured"
+        cursor = nxt
+    last = c.key_path[-1]
+    if not (isinstance(cursor, dict) and last in cursor):
+        return Status.SKIPPED, "not configured"
+    del cursor[last]
+    _atomic_write_text(path, json.dumps(data, indent=2) + "\n")
+    return Status.REMOVED, home_short(path)
+
+
+def _skill_source() -> Path:
+    return Path(str(resources.files("hai_agents_cli.host_skills").joinpath(SKILL_NAME)))
+
+
+def wire_skill(c: Client) -> tuple[Status, str]:
+    """Symlink the bundled SKILL.md into `c`'s skills dir (copy fallback on Windows)."""
+    if c.skills_dir is None:
+        return Status.SKIPPED, "no skill auto-load"
+    home = Path.home()
+    marker = home / (c.home_marker or PurePosixPath(c.skills_dir).parts[0])
+    if not marker.exists():
+        return Status.ABSENT, "host not installed"
+    skills_root = home / c.skills_dir
+    skills_root.mkdir(parents=True, exist_ok=True)
+    link = skills_root / SKILL_NAME
+    source = _skill_source()
+    if link.is_symlink():
+        # strict=False: a fresh-venv install can leave a symlink dangling at removed site-packages.
+        if link.resolve(strict=False) == source.resolve(strict=False):
+            return Status.SKIPPED, home_short(link)
+        link.unlink()
+    elif link.exists():
+        src_md = source / "SKILL.md"
+        skill_md = link / "SKILL.md"
+        is_our_skill = link.is_dir() and skill_md.exists()
+        if is_our_skill and src_md.exists() and skill_md.read_bytes() == src_md.read_bytes():
+            return Status.SKIPPED, home_short(link)
+        if not is_our_skill:
+            return Status.FAILED, f"{home_short(link)} exists and is not a hai skill"
+        shutil.rmtree(link)
+    try:
+        link.symlink_to(source, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        if os.name == "nt":
+            try:
+                shutil.copytree(source, link)
+                return Status.INSTALLED, f"{home_short(link)} (copy; enable Developer Mode for symlinks)"
+            except OSError as copy_exc:
+                return Status.FAILED, f"{link}: {copy_exc}"
+        return Status.FAILED, f"{link}: {exc}"
+    return Status.INSTALLED, home_short(link)
+
+
+def unwire_skill(c: Client) -> tuple[Status, str]:
+    """Remove the symlinked/copied SKILL.md if it is ours."""
+    if c.skills_dir is None:
+        return Status.SKIPPED, "no skill auto-load"
+    link = Path.home() / c.skills_dir / SKILL_NAME
+    source = _skill_source()
+    if link.is_symlink():
+        if link.resolve(strict=False) == source.resolve(strict=False):
+            link.unlink()
+            return Status.REMOVED, home_short(link)
+        return Status.SKIPPED, "not ours"
+    if link.exists():
+        skill_md = link / "SKILL.md"
+        if link.is_dir() and skill_md.exists():
+            shutil.rmtree(link)
+            return Status.REMOVED, home_short(link)
+        return Status.SKIPPED, "not ours"
+    return Status.SKIPPED, "not configured"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from hai_agents_cli import hosts
+from hai_agents_cli.app import app
+from hai_agents_cli.hosts import Client, Status, unwire_mcp, wire_mcp
+
+runner = CliRunner()
+MCP_PATH = "/opt/venv/bin/hai-mcp"
+
+
+@pytest.fixture(autouse=True)
+def _stub_resolve(monkeypatch) -> None:
+    monkeypatch.setattr(hosts, "resolve_mcp_command", lambda: MCP_PATH)
+
+
+def _cursor_host(path) -> Client:
+    return Client(
+        name="Test",
+        config_path=str(path),
+        key_path=("mcpServers", "hai"),
+        leaf={"type": "stdio", "command": hosts.MCP_BINARY},
+    )
+
+
+def test_wire_merges_and_preserves_siblings(tmp_path) -> None:
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({"mcpServers": {"other": {"command": "keep-me"}}}))
+    host = _cursor_host(cfg)
+
+    status, _ = wire_mcp(host)
+
+    assert status is Status.INSTALLED
+    data = json.loads(cfg.read_text())
+    assert data["mcpServers"]["other"] == {"command": "keep-me"}
+    assert data["mcpServers"]["hai"] == {"type": "stdio", "command": MCP_PATH}
+
+
+def test_wire_is_idempotent(tmp_path) -> None:
+    host = _cursor_host(tmp_path / "mcp.json")
+    assert wire_mcp(host)[0] is Status.INSTALLED
+    assert wire_mcp(host)[0] is Status.SKIPPED
+
+
+def test_wire_creates_missing_config(tmp_path) -> None:
+    host = _cursor_host(tmp_path / "nested" / "mcp.json")
+    assert wire_mcp(host)[0] is Status.INSTALLED
+    assert (tmp_path / "nested" / "mcp.json").exists()
+
+
+def test_unwire_removes_only_our_leaf(tmp_path) -> None:
+    cfg = tmp_path / "mcp.json"
+    host = _cursor_host(cfg)
+    wire_mcp(host)
+    cfg.write_text(json.dumps({"mcpServers": {"other": {"command": "keep"}, "hai": {"command": MCP_PATH}}}))
+
+    status, _ = unwire_mcp(host)
+
+    assert status is Status.REMOVED
+    data = json.loads(cfg.read_text())
+    assert "hai" not in data["mcpServers"]
+    assert data["mcpServers"]["other"] == {"command": "keep"}
+
+
+def test_unwire_absent_is_skipped(tmp_path) -> None:
+    assert unwire_mcp(_cursor_host(tmp_path / "mcp.json"))[0] is Status.SKIPPED
+
+
+def test_wire_rejects_invalid_json(tmp_path) -> None:
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text("{not json")
+    assert wire_mcp(_cursor_host(cfg))[0] is Status.FAILED
+
+
+def test_install_list_runs() -> None:
+    result = runner.invoke(app, ["install", "list"])
+    assert result.exit_code == 0
+    assert "cursor" in result.output
+
+
+def test_install_unknown_host_errors() -> None:
+    result = runner.invoke(app, ["install", "nope"])
+    assert result.exit_code == 2


### PR DESCRIPTION
Follow-up to #63 (now merged). Draft while the MCP distribution strategy is finalized.

## What

A one-command way to plug the `hai-mcp` server into the user's coding agents, plus a delegation Skill so those agents know *when* to call H agents.

```bash
hai install            # wire every detected host
hai install cursor     # one host
hai install list       # show supported hosts + which are detected
hai uninstall          # remove from detected hosts
```

## How

- **`src/hai_agents_cli/hosts.py`** — a `CLIENTS` registry (one frozen `Client` per host) with two install modes:
  - **CLI hosts** (Claude Code, Codex) shell out to the host's own `mcp add` / `mcp remove`.
  - **File hosts** (Cursor, Claude Desktop, Copilot CLI, OpenCode, Antigravity) get the server **deep-merged** into their JSON config, preserving siblings, **idempotent** (skips when unchanged), written **atomically** (temp + fsync + rename). The `hai-mcp` command is resolved to an **absolute path** at install time so GUI-launched hosts with a stripped `PATH` still find it.
- **Delegation Skill** (`host_skills/hai-agents/SKILL.md`) symlinked into skill-aware hosts (`.claude/skills`, `.agents/skills`, `.config/opencode/skills`), with a copy fallback on Windows. The prose is grounded in the real tool surface: `run_agent(task, agent, max_steps, max_time_s)`, `list_agents`, `get_session`, `send_message`, `cancel_session`, `share_session`.
- **`hai install` / `hai uninstall`** commands in `app.py`. Adding a host = one `Client` entry.

## Scope notes

- Lean by design: JSON + CLI hosts only, so no PyYAML dependency. YAML hosts (e.g. Hermes) are a trivial later addition.
- No `pyproject` change needed: the bundled `SKILL.md` already lands in the wheel (verified via `uv build`).

## Tests

`tests/test_install.py`: deep-merge preserves siblings, idempotent re-run, creates missing config, `uninstall` removes only our leaf, invalid-JSON is a clean failure, plus `install list` / unknown-host CLI smoke. Also manually verified end-to-end against a throwaway `HOME` (Cursor merge + OpenCode skill symlink + idempotency + uninstall).

## Test plan

- [ ] `hai install list` shows detected hosts
- [ ] `hai install cursor` adds `hai` to `~/.cursor/mcp.json` without clobbering existing servers
- [ ] Fresh Cursor/Claude Code session can call `run_agent`
- [ ] `hai uninstall` cleanly reverses both config and skill