### PR TITLE
chore(sdk): sync to agent_platform@ac84bdd (v0.1.5)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2053,7 +2053,7 @@
           "Agents"
         ],
         "summary": "Get Agent",
-        "description": "Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.",
+        "description": "Fetch by identifier; 404 if not visible. ``resolve=true`` materialises spec leaves.",
         "operationId": "get_agent_api_v2_agents__agent_name__get",
         "security": [
           {
@@ -2069,6 +2069,18 @@
               "type": "string",
               "title": "Agent Name"
             }
+          },
+          {
+            "name": "resolve",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Materialise string environment/skill/subagent leaves into full specs.",
+              "default": false,
+              "title": "Resolve"
+            },
+            "description": "Materialise string environment/skill/subagent leaves into full specs."
           }
         ],
         "responses": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "0.1.4"
+version = "0.1.5"
 description = "Python SDK for H Company's Agent API: autonomous agents powered by Holo."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/hai_agents/agents/client.py
+++ b/src/hai_agents/agents/client.py
@@ -154,13 +154,22 @@ class AgentsClient:
         )
         return _response.data
 
-    def get_agent(self, agent_name: str, *, request_options: typing.Optional[RequestOptions] = None) -> Agent:
+    def get_agent(
+        self,
+        agent_name: str,
+        *,
+        resolve: typing.Optional[bool] = None,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> Agent:
         """
-        Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.
+        Fetch by identifier; 404 if not visible. ``resolve=true`` materialises spec leaves.
 
         Parameters
         ----------
         agent_name : str
+
+        resolve : typing.Optional[bool]
+            Materialise string environment/skill/subagent leaves into full specs.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -181,7 +190,7 @@ class AgentsClient:
             agent_name="agent_name",
         )
         """
-        _response = self._raw_client.get_agent(agent_name, request_options=request_options)
+        _response = self._raw_client.get_agent(agent_name, resolve=resolve, request_options=request_options)
         return _response.data
 
     def update_agent(
@@ -444,13 +453,22 @@ class AsyncAgentsClient:
         )
         return _response.data
 
-    async def get_agent(self, agent_name: str, *, request_options: typing.Optional[RequestOptions] = None) -> Agent:
+    async def get_agent(
+        self,
+        agent_name: str,
+        *,
+        resolve: typing.Optional[bool] = None,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> Agent:
         """
-        Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.
+        Fetch by identifier; 404 if not visible. ``resolve=true`` materialises spec leaves.
 
         Parameters
         ----------
         agent_name : str
+
+        resolve : typing.Optional[bool]
+            Materialise string environment/skill/subagent leaves into full specs.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -479,7 +497,7 @@ class AsyncAgentsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_agent(agent_name, request_options=request_options)
+        _response = await self._raw_client.get_agent(agent_name, resolve=resolve, request_options=request_options)
         return _response.data
 
     async def update_agent(

--- a/src/hai_agents/agents/raw_client.py
+++ b/src/hai_agents/agents/raw_client.py
@@ -212,14 +212,21 @@ class RawAgentsClient:
         raise ApiError(status_code=_response.status_code, headers=dict(_response.headers), body=_response_json)
 
     def get_agent(
-        self, agent_name: str, *, request_options: typing.Optional[RequestOptions] = None
+        self,
+        agent_name: str,
+        *,
+        resolve: typing.Optional[bool] = None,
+        request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[Agent]:
         """
-        Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.
+        Fetch by identifier; 404 if not visible. ``resolve=true`` materialises spec leaves.
 
         Parameters
         ----------
         agent_name : str
+
+        resolve : typing.Optional[bool]
+            Materialise string environment/skill/subagent leaves into full specs.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -232,6 +239,9 @@ class RawAgentsClient:
         _response = self._client_wrapper.httpx_client.request(
             f"api/v2/agents/{encode_path_param(agent_name)}",
             method="GET",
+            params={
+                "resolve": resolve,
+            },
             request_options=request_options,
         )
         try:
@@ -602,14 +612,21 @@ class AsyncRawAgentsClient:
         raise ApiError(status_code=_response.status_code, headers=dict(_response.headers), body=_response_json)
 
     async def get_agent(
-        self, agent_name: str, *, request_options: typing.Optional[RequestOptions] = None
+        self,
+        agent_name: str,
+        *,
+        resolve: typing.Optional[bool] = None,
+        request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[Agent]:
         """
-        Fetch by identifier; 404 if not visible. ``:path`` so slash-containing ids round-trip.
+        Fetch by identifier; 404 if not visible. ``resolve=true`` materialises spec leaves.
 
         Parameters
         ----------
         agent_name : str
+
+        resolve : typing.Optional[bool]
+            Materialise string environment/skill/subagent leaves into full specs.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -622,6 +639,9 @@ class AsyncRawAgentsClient:
         _response = await self._client_wrapper.httpx_client.request(
             f"api/v2/agents/{encode_path_param(agent_name)}",
             method="GET",
+            params={
+                "resolve": resolve,
+            },
             request_options=request_options,
         )
         try:

--- a/uv.lock
+++ b/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "hai-agents"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.1.5` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@ac84bdd
