### PR TITLE
chore(sdk): sync to agent_platform@21778a2 (v0.1.6)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -23,7 +23,7 @@
           "Sessions"
         ],
         "summary": "Create Session",
-        "description": "Create an agentic session.\n\nPass ``Idempotency-Key`` for safe retries: identical requests within 24h\nreturn the original session; reuse with a different body returns 422.",
+        "description": "Create an agentic session.",
         "operationId": "create_session_api_v2_sessions_post",
         "security": [
           {
@@ -1475,7 +1475,7 @@
           "Skills"
         ],
         "summary": "Delete Skill",
-        "description": "Delete by name. Reserved rows: H admin only.",
+        "description": "Delete by name. Reserved rows: H employee only.",
         "operationId": "delete_skill_api_v2_skills__name__delete",
         "security": [
           {
@@ -1835,7 +1835,7 @@
           "Environments"
         ],
         "summary": "Delete Environment",
-        "description": "Delete by identifier. Reserved rows: H admin only.",
+        "description": "Delete by identifier. Reserved rows: H employee only.",
         "operationId": "delete_environment_api_v2_environments__id__delete",
         "security": [
           {
@@ -2167,7 +2167,7 @@
           "Agents"
         ],
         "summary": "Delete Agent",
-        "description": "Delete by identifier. Reserved rows: H admin only.",
+        "description": "Delete by identifier. Reserved rows: H employee only.",
         "operationId": "delete_agent_api_v2_agents__agent_name__delete",
         "security": [
           {
@@ -2428,7 +2428,7 @@
           "page"
         ],
         "title": "EnvironmentPage",
-        "description": "Named page subclass so OpenAPI emits a clean ``EnvironmentPage`` schema name.\n\n``Environment`` is ``Annotated[Browser | CodeSandbox | MCP | Memory, Field(discriminator=\"kind\")]``\nand has no ``__name__``. Without this subclass, Pydantic titles ``Page[Environment]``\nby repr()ing the type parameter, producing a 95-char schema name that leaks\nPydantic FieldInfo into generated SDKs."
+        "description": "Named page subclass so OpenAPI emits a clean ``EnvironmentPage`` schema name."
       },
       "Feedback": {
         "properties": {
@@ -3110,7 +3110,7 @@
           "share_url"
         ],
         "title": "ShareLink",
-        "description": "Public share URL for a session.\n\n``share_url`` is a path; clients prepend the AgP host. Today this points at the\nv1 share router (``/share/api/v1/trajectories/{id}``); will migrate to\n``/share/v1/sessions/{id}`` once the v2 share router lands."
+        "description": "Public share URL for a session."
       },
       "Skill": {
         "properties": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "0.1.5"
+version = "0.1.6"
 description = "Python SDK for H Company's Agent API: autonomous agents powered by Holo."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/hai_agents/agents/client.py
+++ b/src/hai_agents/agents/client.py
@@ -271,7 +271,7 @@ class AgentsClient:
 
     def delete_agent(self, agent_name: str, *, request_options: typing.Optional[RequestOptions] = None) -> None:
         """
-        Delete by identifier. Reserved rows: H admin only.
+        Delete by identifier. Reserved rows: H employee only.
 
         Parameters
         ----------
@@ -586,7 +586,7 @@ class AsyncAgentsClient:
 
     async def delete_agent(self, agent_name: str, *, request_options: typing.Optional[RequestOptions] = None) -> None:
         """
-        Delete by identifier. Reserved rows: H admin only.
+        Delete by identifier. Reserved rows: H employee only.
 
         Parameters
         ----------

--- a/src/hai_agents/agents/raw_client.py
+++ b/src/hai_agents/agents/raw_client.py
@@ -383,7 +383,7 @@ class RawAgentsClient:
         self, agent_name: str, *, request_options: typing.Optional[RequestOptions] = None
     ) -> HttpResponse[None]:
         """
-        Delete by identifier. Reserved rows: H admin only.
+        Delete by identifier. Reserved rows: H employee only.
 
         Parameters
         ----------
@@ -783,7 +783,7 @@ class AsyncRawAgentsClient:
         self, agent_name: str, *, request_options: typing.Optional[RequestOptions] = None
     ) -> AsyncHttpResponse[None]:
         """
-        Delete by identifier. Reserved rows: H admin only.
+        Delete by identifier. Reserved rows: H employee only.
 
         Parameters
         ----------

--- a/src/hai_agents/environments/client.py
+++ b/src/hai_agents/environments/client.py
@@ -198,7 +198,7 @@ class EnvironmentsClient:
 
     def delete_environment(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> None:
         """
-        Delete by identifier. Reserved rows: H admin only.
+        Delete by identifier. Reserved rows: H employee only.
 
         Parameters
         ----------
@@ -440,7 +440,7 @@ class AsyncEnvironmentsClient:
 
     async def delete_environment(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> None:
         """
-        Delete by identifier. Reserved rows: H admin only.
+        Delete by identifier. Reserved rows: H employee only.
 
         Parameters
         ----------

--- a/src/hai_agents/environments/raw_client.py
+++ b/src/hai_agents/environments/raw_client.py
@@ -293,7 +293,7 @@ class RawEnvironmentsClient:
         self, id: str, *, request_options: typing.Optional[RequestOptions] = None
     ) -> HttpResponse[None]:
         """
-        Delete by identifier. Reserved rows: H admin only.
+        Delete by identifier. Reserved rows: H employee only.
 
         Parameters
         ----------
@@ -603,7 +603,7 @@ class AsyncRawEnvironmentsClient:
         self, id: str, *, request_options: typing.Optional[RequestOptions] = None
     ) -> AsyncHttpResponse[None]:
         """
-        Delete by identifier. Reserved rows: H admin only.
+        Delete by identifier. Reserved rows: H employee only.
 
         Parameters
         ----------

--- a/src/hai_agents/sessions/client.py
+++ b/src/hai_agents/sessions/client.py
@@ -146,9 +146,6 @@ class SessionsClient:
         """
         Create an agentic session.
 
-        Pass ``Idempotency-Key`` for safe retries: identical requests within 24h
-        return the original session; reuse with a different body returns 422.
-
         Parameters
         ----------
         agent : SessionRequestAgent
@@ -876,9 +873,6 @@ class AsyncSessionsClient:
     ) -> Session:
         """
         Create an agentic session.
-
-        Pass ``Idempotency-Key`` for safe retries: identical requests within 24h
-        return the original session; reuse with a different body returns 422.
 
         Parameters
         ----------

--- a/src/hai_agents/sessions/raw_client.py
+++ b/src/hai_agents/sessions/raw_client.py
@@ -168,9 +168,6 @@ class RawSessionsClient:
         """
         Create an agentic session.
 
-        Pass ``Idempotency-Key`` for safe retries: identical requests within 24h
-        return the original session; reuse with a different body returns 422.
-
         Parameters
         ----------
         agent : SessionRequestAgent
@@ -1209,9 +1206,6 @@ class AsyncRawSessionsClient:
     ) -> AsyncHttpResponse[Session]:
         """
         Create an agentic session.
-
-        Pass ``Idempotency-Key`` for safe retries: identical requests within 24h
-        return the original session; reuse with a different body returns 422.
 
         Parameters
         ----------

--- a/src/hai_agents/skills/client.py
+++ b/src/hai_agents/skills/client.py
@@ -239,7 +239,7 @@ class SkillsClient:
 
     def delete_skill(self, name: str, *, request_options: typing.Optional[RequestOptions] = None) -> None:
         """
-        Delete by name. Reserved rows: H admin only.
+        Delete by name. Reserved rows: H employee only.
 
         Parameters
         ----------
@@ -525,7 +525,7 @@ class AsyncSkillsClient:
 
     async def delete_skill(self, name: str, *, request_options: typing.Optional[RequestOptions] = None) -> None:
         """
-        Delete by name. Reserved rows: H admin only.
+        Delete by name. Reserved rows: H employee only.
 
         Parameters
         ----------

--- a/src/hai_agents/skills/raw_client.py
+++ b/src/hai_agents/skills/raw_client.py
@@ -329,7 +329,7 @@ class RawSkillsClient:
 
     def delete_skill(self, name: str, *, request_options: typing.Optional[RequestOptions] = None) -> HttpResponse[None]:
         """
-        Delete by name. Reserved rows: H admin only.
+        Delete by name. Reserved rows: H employee only.
 
         Parameters
         ----------
@@ -683,7 +683,7 @@ class AsyncRawSkillsClient:
         self, name: str, *, request_options: typing.Optional[RequestOptions] = None
     ) -> AsyncHttpResponse[None]:
         """
-        Delete by name. Reserved rows: H admin only.
+        Delete by name. Reserved rows: H employee only.
 
         Parameters
         ----------

--- a/src/hai_agents/types/environment_page.py
+++ b/src/hai_agents/types/environment_page.py
@@ -10,11 +10,6 @@ from .environment import Environment
 class EnvironmentPage(UniversalBaseModel):
     """
     Named page subclass so OpenAPI emits a clean ``EnvironmentPage`` schema name.
-
-    ``Environment`` is ``Annotated[Browser | CodeSandbox | MCP | Memory, Field(discriminator="kind")]``
-    and has no ``__name__``. Without this subclass, Pydantic titles ``Page[Environment]``
-    by repr()ing the type parameter, producing a 95-char schema name that leaks
-    Pydantic FieldInfo into generated SDKs.
     """
 
     items: typing.List[Environment]

--- a/src/hai_agents/types/share_link.py
+++ b/src/hai_agents/types/share_link.py
@@ -9,10 +9,6 @@ from ..core.pydantic_utilities import IS_PYDANTIC_V2, UniversalBaseModel
 class ShareLink(UniversalBaseModel):
     """
     Public share URL for a session.
-
-    ``share_url`` is a path; clients prepend the AgP host. Today this points at the
-    v1 share router (``/share/api/v1/trajectories/{id}``); will migrate to
-    ``/share/v1/sessions/{id}`` once the v2 share router lands.
     """
 
     share_url: str

--- a/uv.lock
+++ b/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "hai-agents"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.1.6` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@21778a2
