### PR TITLE
feat(cli): hai mcp install

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,14 @@ hai sessions get <session-id>
 hai sessions send <session-id> "continue"
 hai sessions cancel <session-id>
 hai sessions share <session-id>
+hai mcp install            # wire the hai-agents MCP server into every detected editor
+hai mcp install list       # see supported clients (Cursor, VS Code, Claude Code, Windsurf)
 ```
+
+`hai mcp install` adds the remote `hai-agents` MCP server to your local editors and
+writes your API key into each client config (in plaintext, so keep them private). On
+clients that support agent skills (Cursor, Claude Code) it also symlinks a `SKILL.md`
+that teaches the model how to drive the server.
 
 `hai login` opens your browser, mints a per-machine API key, and writes it to
 `~/.config/hai/.env`. `hai whoami` shows the resolved endpoint and whether you are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "0.1.5"
+version = "0.1.6"
 description = "Python SDK for H Company's Agent API: autonomous agents powered by Holo."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/hai_agents_cli/app.py
+++ b/src/hai_agents_cli/app.py
@@ -20,7 +20,7 @@ from hai_agents_common import credentials
 from hai_agents_common.credentials import absolute_share_url, make_client
 from hai_agents_common.jsonable import to_jsonable
 
-from . import auth
+from . import auth, mcp_hosts
 
 H_GLYPH = "\n".join(
     (
@@ -46,6 +46,7 @@ app = typer.Typer(
     rich_markup_mode=None,
 )
 sessions_app = typer.Typer(no_args_is_help=True, help="Inspect and steer sessions.")
+mcp_app = typer.Typer(no_args_is_help=True, help="Manage the hai-agents MCP server.")
 
 
 @dataclass(frozen=True)
@@ -266,7 +267,100 @@ def share(ctx: typer.Context, session_id: str = typer.Argument(...)) -> None:
         print(share_url)
 
 
+@mcp_app.command("install")
+def mcp_install(
+    ctx: typer.Context,
+    client: str = typer.Argument(
+        None, help="Client id (cursor, vscode, ...), 'list' to enumerate, or omit to wire every detected client."
+    ),
+    url: str = typer.Option(None, "--url", help="MCP endpoint. Defaults to your --base-url region or the EU host."),
+) -> None:
+    """Wire the hai-agents MCP server into local clients (writes your API key into each config in plaintext)."""
+    state = _state(ctx)
+    if client == "list":
+        _mcp_list(state.json_output)
+        return
+
+    if client is None:
+        targets = [(cid, c) for cid, c in mcp_hosts.CLIENTS.items() if mcp_hosts.host_present(c)]
+        if not targets:
+            _raise_cli_error(RuntimeError("No supported MCP clients detected. Run `hai mcp install list`."))
+    elif client in mcp_hosts.CLIENTS:
+        targets = [(client, mcp_hosts.CLIENTS[client])]
+    else:
+        _raise_cli_error(RuntimeError(f"Unknown client {client!r}. Run `hai mcp install list` to see supported ids."))
+
+    try:
+        resolved = credentials.resolve_api_key(state.api_key)
+        key = resolved() if callable(resolved) else resolved
+    except RuntimeError as exc:
+        _raise_cli_error(exc)
+    server_url = mcp_hosts.resolve_mcp_url(credentials.resolve_base_url(state.base_url), url)
+
+    results = [_install_one(cid, c, server_url, key) for cid, c in targets]
+    _print_mcp_results(results, server_url, state.json_output)
+    if any(r["status"].fatal or (r["skill"] and r["skill"][0].fatal) for r in results):
+        raise typer.Exit(1)
+
+
+def _install_one(cid: str, c: mcp_hosts.Client, url: str, key: str) -> dict:
+    status, detail = mcp_hosts.wire_mcp(c, url, key)
+    skill = mcp_hosts.wire_skill(c) if c.skills_dir is not None else None
+    return {"client": cid, "status": status, "detail": detail, "skill": skill}
+
+
+def _mcp_list(json_output: bool) -> None:
+    rows = [(cid, mcp_hosts.host_present(c), mcp_hosts.host_target(c)) for cid, c in mcp_hosts.CLIENTS.items()]
+    if json_output:
+        _print_json({cid: {"detected": detected, "target": tgt} for cid, detected, tgt in rows})
+        return
+    table = Table("Client", "Detected", "Config")
+    for cid, detected, tgt in rows:
+        table.add_row(cid, "[green]yes[/green]" if detected else "[dim]no[/dim]", tgt)
+    console.print(table)
+    console.print(
+        "[dim]Wire one with[/dim] [cyan]hai mcp install <id>[/cyan][dim], or all detected with[/dim] [cyan]hai mcp install[/cyan]."
+    )
+
+
+_MCP_GLYPH: dict[mcp_hosts.Status, str] = {
+    mcp_hosts.Status.INSTALLED: "[bold green]+[/bold green]",
+    mcp_hosts.Status.SKIPPED: "[dim green]=[/dim green]",
+    mcp_hosts.Status.ABSENT: "[yellow]-[/yellow]",
+    mcp_hosts.Status.FAILED: "[bold red]x[/bold red]",
+}
+
+
+def _print_mcp_results(results: list[dict], server_url: str, json_output: bool) -> None:
+    if json_output:
+        _print_json(
+            {
+                "url": server_url,
+                "results": [
+                    {
+                        "client": r["client"],
+                        "status": r["status"].value,
+                        "detail": r["detail"],
+                        "skill": ({"status": r["skill"][0].value, "detail": r["skill"][1]} if r["skill"] else None),
+                    }
+                    for r in results
+                ],
+            }
+        )
+        return
+    for r in results:
+        line = f"  {_MCP_GLYPH[r['status']]} [bold cyan]{r['client']}[/bold cyan]  {r['detail']}"
+        if r["skill"] and r["skill"][0].ok:
+            line += f"  [dim]+ skill {r['skill'][1]}[/dim]"
+        elif r["skill"]:
+            line += f"  {_MCP_GLYPH[r['skill'][0]]} [dim]skill: {r['skill'][1]}[/dim]"
+        console.print(line)
+    console.print(f"\n[bold]Server:[/bold] {server_url}")
+    console.print("[yellow]Your API key was written into these configs in plaintext. Keep them private.[/yellow]")
+
+
 app.add_typer(sessions_app, name="sessions")
+app.add_typer(mcp_app, name="mcp")
 
 
 def main() -> None:

--- a/src/hai_agents_cli/host_skills/hai-agents/SKILL.md
+++ b/src/hai_agents_cli/host_skills/hai-agents/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: hai-agents
+description: Delegate a task to an autonomous H Company agent (Holo-powered web surfer and computer-use agents) through the hai-agents MCP server. Use to offload open-ended browser or research work that the agent should carry out end to end on its own infrastructure, then report a final answer. Runs remotely, so it is the right tool when the work is "go do this on the web and come back with the result" rather than something you can answer directly or do with local files.
+---
+
+# hai-agents
+
+The `hai-agents` MCP server runs H Company's autonomous agents (e.g. the `h/web-surfer-holo3` family) on H Company's infrastructure and streams back a single answer. You hand an agent a self-contained `task`; it opens its own browse-and-act loop in a remote browser and works until it has an answer, hits its step or time budget, or is cancelled. Nothing runs on the user's machine.
+
+The agent is blind to this conversation. It sees only the `task` string, so fold in the context it needs: which site or source, what "done" looks like, the shape of the answer you want back. Keep the user's own action verbs and any literal text (search queries, message bodies) verbatim, since the agent grounds well on natural imperatives. Paraphrase by adding context, not by rewording.
+
+Use it for open-ended work on the live web: finding and extracting information across pages, filling in and submitting forms, multi-step navigation behind logins the agent can perform, and research that needs a real browser. It is the wrong tool when the answer is already in your knowledge or a single fetch, when the job is local file, shell, or code work, or when the user wants something written or explained in the conversation rather than done on the web.
+
+## Tools
+
+- `list_agents()` — agents the caller can run (their org's plus the public `h/` ones). Pick the `agent` name from here.
+- `run_agent(task, agent, max_steps?, max_time_s?, idempotency_key?)` — start a run. Returns either the final answer or a session handle `{ session_id, status, answer, done }`.
+- `wait_for_session(session_id, wait=True)` — long-poll a running session for its answer; `wait=False` returns the current snapshot without blocking.
+- `send_message(session_id, message)` — steer a running session with a follow-up.
+- `cancel_session(session_id)` — stop a run you no longer need.
+- `share_session(session_id)` — get a public read-only URL for the run.
+
+## Long-running tasks
+
+MCP clients cap a single tool call at roughly a minute, but agent runs often take longer, so the server long-polls instead of blocking the whole time:
+
+1. Call `run_agent`. It waits up to about 24 seconds, then returns either the final answer or a handle with `done: false`.
+2. If `done` is false, call `wait_for_session(session_id)` to keep long-polling.
+3. Repeat `wait_for_session` until `done` is true, then surface the answer.
+
+This loop is the whole protocol: a run that finishes fast returns straight from `run_agent`; a long one is just more `wait_for_session` calls. Treat the work as long-running — do not give the user a final answer while a session is still in flight, and if a run fails or times out, refine the `task` with more specifics and retry, or surface the failure.
+
+## Examples
+
+User: *"find the cheapest direct flight from Paris to Lisbon next Friday"*
+
+    run_agent
+      agent: h/web-surfer-holo3-1-35b
+      task: On Google Flights, find the cheapest direct (non-stop) flight from Paris (any CDG/ORY) to Lisbon (LIS) departing next Friday, returning the airline, departure and arrival times, and total price in EUR.
+
+User: *"is the H Company Agent API quickstart still showing the curl example"*
+
+    run_agent
+      agent: h/web-surfer-holo3-1-35b
+      task: Open https://hub.hcompany.ai/agent-api and confirm whether the quickstart page still shows a curl example. Return yes or no and quote the first line of the example if present.

--- a/src/hai_agents_cli/mcp_hosts.py
+++ b/src/hai_agents_cli/mcp_hosts.py
@@ -1,0 +1,252 @@
+"""MCP client registry + install dispatch for the remote `hai-agents` server. Add a client = add one `Client`."""
+
+from __future__ import annotations
+
+import enum
+import json
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+SERVER_NAME = "hai-agents"
+DEFAULT_MCP_URL = "https://agp.eu.hcompany.ai/mcp"
+
+# Placeholders kept in the registry leaves; substituted with the live endpoint + key at wire time.
+_URL = "__MCP_URL__"
+_KEY = "__MCP_KEY__"
+
+
+def _bearer_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_KEY}"}
+
+
+class Status(enum.Enum):
+    """Outcome of one install step."""
+
+    INSTALLED = "installed"
+    SKIPPED = "skipped"
+    ABSENT = "absent"
+    FAILED = "failed"
+
+    @property
+    def ok(self) -> bool:
+        return self in (Status.INSTALLED, Status.SKIPPED)
+
+    @property
+    def fatal(self) -> bool:
+        return self is Status.FAILED
+
+
+@dataclass(frozen=True)
+class Client:
+    """One MCP client: CLI clients set `cli_cmd`; file clients set `config_path` + `key_path` + `leaf`."""
+
+    name: str
+    config_path: str | None = None
+    cli_cmd: tuple[str, ...] | None = None
+    key_path: tuple[str, ...] | None = None
+    leaf: dict[str, Any] | None = None
+    skills_dir: str | None = None  # under $HOME; None if the client has no SKILL.md auto-load
+
+
+def _vscode_config_path(app_dir: str) -> str:
+    """Per-OS user-level VS Code MCP config for the given app directory (`Code`, `Code - Insiders`)."""
+    system = platform.system()
+    if system == "Windows":
+        appdata = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return str(Path(appdata) / app_dir / "User" / "mcp.json")
+    if system == "Darwin":
+        return f"~/Library/Application Support/{app_dir}/User/mcp.json"
+    xdg = os.environ.get("XDG_CONFIG_HOME") or "~/.config"
+    return f"{xdg}/{app_dir}/User/mcp.json"
+
+
+CLIENTS: dict[str, Client] = {
+    "cursor": Client(
+        name="Cursor",
+        config_path="~/.cursor/mcp.json",
+        key_path=("mcpServers", SERVER_NAME),
+        leaf={"url": _URL, "headers": _bearer_headers()},
+        skills_dir=".cursor/skills",
+    ),
+    "vscode": Client(
+        name="VS Code",
+        config_path=_vscode_config_path("Code"),
+        key_path=("servers", SERVER_NAME),
+        leaf={"type": "http", "url": _URL, "headers": _bearer_headers()},
+    ),
+    "vscode-insiders": Client(
+        name="VS Code Insiders",
+        config_path=_vscode_config_path("Code - Insiders"),
+        key_path=("servers", SERVER_NAME),
+        leaf={"type": "http", "url": _URL, "headers": _bearer_headers()},
+    ),
+    "claude-code": Client(
+        name="Claude Code",
+        cli_cmd=(
+            "claude",
+            "mcp",
+            "add",
+            "--transport",
+            "http",
+            SERVER_NAME,
+            _URL,
+            "--header",
+            f"Authorization: Bearer {_KEY}",
+        ),
+        skills_dir=".claude/skills",
+    ),
+    "windsurf": Client(
+        name="Windsurf",
+        config_path="~/.codeium/windsurf/mcp_config.json",
+        key_path=("mcpServers", SERVER_NAME),
+        leaf={"serverUrl": _URL, "headers": _bearer_headers()},
+    ),
+}
+
+
+def resolve_mcp_url(base_url: str | None, override: str | None) -> str:
+    """MCP endpoint: explicit override, else the base URL's origin + `/mcp`, else the EU host."""
+    if override:
+        return override
+    if base_url:
+        parts = urlsplit(base_url)
+        if parts.scheme and parts.netloc:
+            return urlunsplit((parts.scheme, parts.netloc, "/mcp", "", ""))
+    return DEFAULT_MCP_URL
+
+
+def host_present(c: Client) -> bool:
+    """True if the client looks installed: its CLI is on PATH, or its config directory exists."""
+    if c.cli_cmd is not None:
+        return shutil.which(c.cli_cmd[0]) is not None
+    assert c.config_path is not None
+    path = Path(c.config_path).expanduser()
+    return path.exists() or path.parent.exists()
+
+
+def host_target(c: Client) -> str:
+    """Where the config lands (~-path), or 'via CLI' for CLI-managed clients."""
+    return _home_short(c.config_path) if c.config_path else "via CLI"
+
+
+def wire_skill(c: Client) -> tuple[Status, str]:
+    """Symlink the bundled hai-agents SKILL.md into `c`'s skills dir so the host auto-loads it."""
+    if c.skills_dir is None:
+        return Status.SKIPPED, "no skill auto-load"
+    home = Path.home()
+    if not (home / PurePosixPath(c.skills_dir).parts[0]).exists():
+        return Status.ABSENT, "client not installed"
+    skills_root = home / c.skills_dir
+    skills_root.mkdir(parents=True, exist_ok=True)
+    link = skills_root / SERVER_NAME
+    source = Path(str(resources.files("hai_agents_cli.host_skills").joinpath(SERVER_NAME)))
+    if link.is_symlink():
+        # strict=False: a reinstall can leave the link dangling at a removed site-packages path.
+        if link.resolve(strict=False) == source.resolve(strict=False):
+            return Status.SKIPPED, _home_short(str(link))
+        link.unlink()
+    elif link.exists():
+        skill_md, src_md = link / "SKILL.md", source / "SKILL.md"
+        is_ours = link.is_dir() and skill_md.exists()
+        if is_ours and src_md.exists() and skill_md.read_bytes() == src_md.read_bytes():
+            return Status.SKIPPED, _home_short(str(link))
+        if not is_ours:
+            return Status.FAILED, f"{_home_short(str(link))} exists and is not a hai-agents skill"
+        shutil.rmtree(link)
+    try:
+        link.symlink_to(source, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        # Windows without Developer Mode can't symlink; mirror the tree as a fallback.
+        if os.name == "nt":
+            try:
+                shutil.copytree(source, link)
+            except OSError as copy_exc:
+                return Status.FAILED, f"{link}: {copy_exc}"
+            return Status.INSTALLED, f"{_home_short(str(link))} (copy; enable Developer Mode for symlinks)"
+        return Status.FAILED, f"{link}: {exc}"
+    return Status.INSTALLED, _home_short(str(link))
+
+
+def wire_mcp(c: Client, url: str, key: str) -> tuple[Status, str]:
+    """Install the server into `c`: a CLI `add`, or a JSON config merge."""
+    if c.cli_cmd is not None:
+        return _install_via_cli([_render(arg, url, key) for arg in c.cli_cmd])
+    assert c.config_path is not None and c.key_path is not None and c.leaf is not None
+    return _wire_json(Path(c.config_path).expanduser(), c.key_path, _render(c.leaf, url, key))
+
+
+def _render(obj: Any, url: str, key: str) -> Any:
+    """Deep-copy `obj`, substituting the URL and key placeholders in every string."""
+    if isinstance(obj, str):
+        return obj.replace(_URL, url).replace(_KEY, key)
+    if isinstance(obj, dict):
+        return {k: _render(v, url, key) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_render(x, url, key) for x in obj]
+    return obj
+
+
+def _install_via_cli(cmd: list[str]) -> tuple[Status, str]:
+    exe = shutil.which(cmd[0])
+    if exe is None:
+        return Status.ABSENT, f"{cmd[0]!r} not on PATH"
+    try:
+        subprocess.run([exe, *cmd[1:]], check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        msg = (exc.stderr or exc.stdout or str(exc)).strip()
+        if "already" in msg.lower():
+            return Status.SKIPPED, f"{cmd[0]} already configured"
+        return Status.FAILED, msg
+    return Status.INSTALLED, f"via {cmd[0]} CLI"
+
+
+def _wire_json(path: Path, key_path: tuple[str, ...], leaf: dict[str, Any]) -> tuple[Status, str]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data: dict[str, Any] = {}
+    if path.exists() and path.stat().st_size > 0:
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            return Status.FAILED, f"{path}: invalid JSON ({exc})"
+        if not isinstance(loaded, dict):
+            return Status.FAILED, f"{path}: top-level is not an object"
+        data = loaded
+    cursor: Any = data
+    for k in key_path[:-1]:
+        cursor = cursor.setdefault(k, {})
+        if not isinstance(cursor, dict):
+            return Status.FAILED, f"{path}: {k!r} is not an object"
+    last = key_path[-1]
+    if cursor.get(last) == leaf:
+        return Status.SKIPPED, _home_short(str(path))
+    cursor[last] = leaf
+    _atomic_write_secret(path, json.dumps(data, indent=2) + "\n")
+    return Status.INSTALLED, _home_short(str(path))
+
+
+def _atomic_write_secret(path: Path, content: str) -> None:
+    """Write to a sibling temp then `rename` over the target, chmod 600 (the file embeds an API key)."""
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except Exception:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def _home_short(p: str) -> str:
+    home = str(Path.home())
+    return "~" + p[len(home) :] if p.startswith(home) else p

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import stat
+
+from typer.testing import CliRunner
+
+from hai_agents_cli import mcp_hosts
+from hai_agents_cli.app import app
+from hai_agents_cli.mcp_hosts import Client, Status, resolve_mcp_url, wire_mcp, wire_skill
+
+runner = CliRunner()
+
+
+def test_resolve_mcp_url_prefers_override_then_base_origin_then_eu() -> None:
+    assert resolve_mcp_url(None, None) == mcp_hosts.DEFAULT_MCP_URL
+    assert resolve_mcp_url(None, "https://x.test/mcp") == "https://x.test/mcp"
+    assert resolve_mcp_url("https://agp.staging.sandboxh.ai/api/v2", None) == "https://agp.staging.sandboxh.ai/mcp"
+
+
+def test_registry_leaves_carry_bearer_and_client_specific_url_key() -> None:
+    rendered = {
+        cid: mcp_hosts._render(c.leaf, "https://u/mcp", "hk-1") for cid, c in mcp_hosts.CLIENTS.items() if c.leaf
+    }
+    assert rendered["cursor"] == {"url": "https://u/mcp", "headers": {"Authorization": "Bearer hk-1"}}
+    assert rendered["vscode"]["type"] == "http" and rendered["vscode"]["url"] == "https://u/mcp"
+    assert rendered["windsurf"]["serverUrl"] == "https://u/mcp"
+
+
+def test_wire_json_merges_preserves_and_is_idempotent(tmp_path) -> None:
+    path = tmp_path / "mcp.json"
+    path.write_text(json.dumps({"mcpServers": {"other": {"url": "keep"}}}), encoding="utf-8")
+    c = Client(
+        name="X",
+        config_path=str(path),
+        key_path=("mcpServers", "hai-agents"),
+        leaf={"url": mcp_hosts._URL, "headers": {"Authorization": f"Bearer {mcp_hosts._KEY}"}},
+    )
+
+    status, _ = wire_mcp(c, "https://u/mcp", "hk-secret")
+    assert status is Status.INSTALLED
+    data = json.loads(path.read_text())
+    assert data["mcpServers"]["other"] == {"url": "keep"}
+    assert data["mcpServers"]["hai-agents"] == {
+        "url": "https://u/mcp",
+        "headers": {"Authorization": "Bearer hk-secret"},
+    }
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    assert wire_mcp(c, "https://u/mcp", "hk-secret")[0] is Status.SKIPPED
+
+
+def test_install_writes_detected_client_and_warns(monkeypatch, tmp_path) -> None:
+    path = tmp_path / "mcp.json"
+    monkeypatch.setitem(
+        mcp_hosts.CLIENTS,
+        "cursor",
+        Client(
+            name="Cursor",
+            config_path=str(path),
+            key_path=("mcpServers", "hai-agents"),
+            leaf=mcp_hosts.CLIENTS["cursor"].leaf,
+        ),
+    )
+
+    result = runner.invoke(app, ["mcp", "install", "cursor"], env={"HAI_API_KEY": "hk-test"})
+
+    assert result.exit_code == 0, result.output
+    assert "plaintext" in result.output
+    assert json.loads(path.read_text())["mcpServers"]["hai-agents"]["headers"]["Authorization"] == "Bearer hk-test"
+
+
+def test_install_requires_api_key(monkeypatch, tmp_path) -> None:
+    from hai_agents_common import credentials
+
+    monkeypatch.delenv("HAI_API_KEY", raising=False)
+    monkeypatch.delenv("H_API_KEY", raising=False)
+    monkeypatch.setattr(credentials, "LOCAL_ENV_PATH", tmp_path / "local.env")
+    monkeypatch.setattr(credentials, "GLOBAL_ENV_PATH", tmp_path / "global.env")
+
+    result = runner.invoke(app, ["mcp", "install", "cursor"], env={})
+
+    assert result.exit_code != 0
+    text = "\n".join(part for part in (result.output, result.stderr, str(result.exception)) if part)
+    assert "No API key found" in text
+
+
+def test_install_list_enumerates_clients() -> None:
+    result = runner.invoke(app, ["mcp", "install", "list"])
+
+    assert result.exit_code == 0
+    assert "cursor" in result.output and "windsurf" in result.output
+
+
+def test_wire_skill_symlinks_bundled_skill_and_is_idempotent(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".cursor").mkdir()
+    c = Client(name="X", skills_dir=".cursor/skills")
+
+    assert wire_skill(c)[0] is Status.INSTALLED
+    link = tmp_path / ".cursor" / "skills" / "hai-agents"
+    assert link.is_symlink() and (link / "SKILL.md").exists()
+    assert wire_skill(c)[0] is Status.SKIPPED
+
+
+def test_wire_skill_absent_when_client_dir_missing(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert wire_skill(Client(name="X", skills_dir=".cursor/skills"))[0] is Status.ABSENT


### PR DESCRIPTION
Add `hai mcp install` to wire the remote hai-agents MCP server (and a bundled SKILL.md) into Cursor, VS Code, Claude Code, and Windsurf.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Install writes the user's API key into local editor MCP configs in plaintext (mitigated by chmod 600 and explicit warnings); otherwise local-only config changes with no server-side auth changes.
> 
> **Overview**
> Adds **`hai mcp install`** (and **`hai mcp install list`**) so users can register the remote **`hai-agents`** MCP server in local editors without hand-editing JSON.
> 
> The CLI resolves the MCP URL from `--url`, the configured Agent Platform **`--base-url`**, or the EU default, requires a resolved API key, then **merges or CLI-adds** server entries for **Cursor, VS Code (incl. Insiders), Claude Code, and Windsurf**. Config writes use **atomic writes with mode 600** where JSON is updated; the command **warns that keys are stored in plaintext** in those files.
> 
> For **Cursor and Claude Code**, it also installs a bundled **`SKILL.md`** (symlink, with a Windows copy fallback) so hosts know how to drive **`run_agent`** / **`wait_for_session`**. **`mcp_hosts.py`** centralizes per-client config shapes; **`tests/test_mcp_install.py`** covers URL resolution, JSON merge/idempotency, CLI flows, and skill wiring. README documents the commands; package version bumps to **0.1.6**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cb7e8a64b39baa9b4074c839171e43bcfd12265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->