### PR TITLE
fix(cli): Claude MCP user scope + rewrite stale key on reinstall

### DIFF
--- a/src/hai_agents_cli/mcp_hosts.py
+++ b/src/hai_agents_cli/mcp_hosts.py
@@ -51,6 +51,7 @@ class Client:
     name: str
     config_path: str | None = None
     cli_cmd: tuple[str, ...] | None = None
+    cli_remove_cmd: tuple[str, ...] | None = None
     key_path: tuple[str, ...] | None = None
     leaf: dict[str, Any] | None = None
     skills_dir: str | None = None  # under $HOME; None if the client has no SKILL.md auto-load
@@ -94,6 +95,8 @@ CLIENTS: dict[str, Client] = {
             "claude",
             "mcp",
             "add",
+            "--scope",
+            "user",
             "--transport",
             "http",
             SERVER_NAME,
@@ -101,6 +104,7 @@ CLIENTS: dict[str, Client] = {
             "--header",
             f"Authorization: Bearer {_KEY}",
         ),
+        cli_remove_cmd=("claude", "mcp", "remove", "--scope", "user", SERVER_NAME),
         skills_dir=".claude/skills",
     ),
     "windsurf": Client(
@@ -178,7 +182,9 @@ def wire_skill(c: Client) -> tuple[Status, str]:
 def wire_mcp(c: Client, url: str, key: str) -> tuple[Status, str]:
     """Install the server into `c`: a CLI `add`, or a JSON config merge."""
     if c.cli_cmd is not None:
-        return _install_via_cli([_render(arg, url, key) for arg in c.cli_cmd])
+        add = [_render(arg, url, key) for arg in c.cli_cmd]
+        remove = list(c.cli_remove_cmd) if c.cli_remove_cmd else None
+        return _install_via_cli(add, remove)
     assert c.config_path is not None and c.key_path is not None and c.leaf is not None
     return _wire_json(Path(c.config_path).expanduser(), c.key_path, _render(c.leaf, url, key))
 
@@ -194,18 +200,19 @@ def _render(obj: Any, url: str, key: str) -> Any:
     return obj
 
 
-def _install_via_cli(cmd: list[str]) -> tuple[Status, str]:
-    exe = shutil.which(cmd[0])
+def _install_via_cli(add_cmd: list[str], remove_cmd: list[str] | None = None) -> tuple[Status, str]:
+    exe = shutil.which(add_cmd[0])
     if exe is None:
-        return Status.ABSENT, f"{cmd[0]!r} not on PATH"
+        return Status.ABSENT, f"{add_cmd[0]!r} not on PATH"
+    # `add` refuses to overwrite, so drop any existing entry first; otherwise a rotated key or
+    # changed url is silently kept. Re-adding always reflects the current url + key.
+    if remove_cmd is not None:
+        subprocess.run([exe, *remove_cmd[1:]], capture_output=True, text=True, check=False)
     try:
-        subprocess.run([exe, *cmd[1:]], check=True, capture_output=True, text=True)
+        subprocess.run([exe, *add_cmd[1:]], check=True, capture_output=True, text=True)
     except subprocess.CalledProcessError as exc:
-        msg = (exc.stderr or exc.stdout or str(exc)).strip()
-        if "already" in msg.lower():
-            return Status.SKIPPED, f"{cmd[0]} already configured"
-        return Status.FAILED, msg
-    return Status.INSTALLED, f"via {cmd[0]} CLI"
+        return Status.FAILED, (exc.stderr or exc.stdout or str(exc)).strip()
+    return Status.INSTALLED, f"via {add_cmd[0]} CLI"
 
 
 def _wire_json(path: Path, key_path: tuple[str, ...], leaf: dict[str, Any]) -> tuple[Status, str]:

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import stat
+import subprocess
 
 from typer.testing import CliRunner
 
@@ -48,6 +49,25 @@ def test_wire_json_merges_preserves_and_is_idempotent(tmp_path) -> None:
     assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
     assert wire_mcp(c, "https://u/mcp", "hk-secret")[0] is Status.SKIPPED
+
+
+def test_cli_install_removes_then_adds_at_user_scope(monkeypatch) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(mcp_hosts.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def fake_run(cmd, **_):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(mcp_hosts.subprocess, "run", fake_run)
+
+    status, _ = wire_mcp(mcp_hosts.CLIENTS["claude-code"], "https://u/mcp", "hk-rotated")
+
+    assert status is Status.INSTALLED
+    remove, add = calls
+    assert remove[1:3] == ["mcp", "remove"] and remove[remove.index("--scope") + 1] == "user"
+    assert add[1:3] == ["mcp", "add"] and add[add.index("--scope") + 1] == "user"
+    assert "Authorization: Bearer hk-rotated" in add
 
 
 def test_install_writes_detected_client_and_warns(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
Installs the Claude Code MCP server at `--scope user` (global, not project-local) and removes-then-adds so a rotated key or changed url is rewritten instead of skipped. Fixes two Bugbot findings on #78.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local CLI MCP config only for Claude Code; remove is best-effort and JSON-based clients are unchanged.
> 
> **Overview**
> **Claude Code MCP install** now targets **user scope** (`--scope user` on add/remove) so the server is registered globally instead of project-local.
> 
> CLI wiring runs **`mcp remove` then `mcp add`** before reporting success, so reinstalls pick up a **rotated API key or URL** instead of leaving the old entry and returning skipped. The optional `cli_remove_cmd` on `Client` drives that flow; the previous “already configured” skip on CLI add is removed.
> 
> A unit test asserts remove-then-add order and user scope for the Claude Code client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4317ceee86ecfe426860c84029ba8d53040fe3d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->