### PR TITLE
fix(cli): clear stale local-scope Claude MCP entry on reinstall

### DIFF
--- a/src/hai_agents_cli/mcp_hosts.py
+++ b/src/hai_agents_cli/mcp_hosts.py
@@ -51,7 +51,7 @@ class Client:
     name: str
     config_path: str | None = None
     cli_cmd: tuple[str, ...] | None = None
-    cli_remove_cmd: tuple[str, ...] | None = None
+    cli_remove_cmds: tuple[tuple[str, ...], ...] = ()
     key_path: tuple[str, ...] | None = None
     leaf: dict[str, Any] | None = None
     skills_dir: str | None = None  # under $HOME; None if the client has no SKILL.md auto-load
@@ -104,7 +104,12 @@ CLIENTS: dict[str, Client] = {
             "--header",
             f"Authorization: Bearer {_KEY}",
         ),
-        cli_remove_cmd=("claude", "mcp", "remove", "--scope", "user", SERVER_NAME),
+        cli_remove_cmds=(
+            # Clear any prior entry at either writable scope so a rotated key / url can't survive,
+            # and a narrower local entry can't shadow the user-scoped one we install.
+            ("claude", "mcp", "remove", "--scope", "local", SERVER_NAME),
+            ("claude", "mcp", "remove", "--scope", "user", SERVER_NAME),
+        ),
         skills_dir=".claude/skills",
     ),
     "windsurf": Client(
@@ -183,8 +188,8 @@ def wire_mcp(c: Client, url: str, key: str) -> tuple[Status, str]:
     """Install the server into `c`: a CLI `add`, or a JSON config merge."""
     if c.cli_cmd is not None:
         add = [_render(arg, url, key) for arg in c.cli_cmd]
-        remove = list(c.cli_remove_cmd) if c.cli_remove_cmd else None
-        return _install_via_cli(add, remove)
+        removes = [list(rm) for rm in c.cli_remove_cmds]
+        return _install_via_cli(add, removes)
     assert c.config_path is not None and c.key_path is not None and c.leaf is not None
     return _wire_json(Path(c.config_path).expanduser(), c.key_path, _render(c.leaf, url, key))
 
@@ -200,14 +205,14 @@ def _render(obj: Any, url: str, key: str) -> Any:
     return obj
 
 
-def _install_via_cli(add_cmd: list[str], remove_cmd: list[str] | None = None) -> tuple[Status, str]:
+def _install_via_cli(add_cmd: list[str], remove_cmds: list[list[str]] | None = None) -> tuple[Status, str]:
     exe = shutil.which(add_cmd[0])
     if exe is None:
         return Status.ABSENT, f"{add_cmd[0]!r} not on PATH"
     # `add` refuses to overwrite, so drop any existing entry first; otherwise a rotated key or
     # changed url is silently kept. Re-adding always reflects the current url + key.
-    if remove_cmd is not None:
-        subprocess.run([exe, *remove_cmd[1:]], capture_output=True, text=True, check=False)
+    for rm in remove_cmds or []:
+        subprocess.run([exe, *rm[1:]], capture_output=True, text=True, check=False)
     try:
         subprocess.run([exe, *add_cmd[1:]], check=True, capture_output=True, text=True)
     except subprocess.CalledProcessError as exc:

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -64,8 +64,9 @@ def test_cli_install_removes_then_adds_at_user_scope(monkeypatch) -> None:
     status, _ = wire_mcp(mcp_hosts.CLIENTS["claude-code"], "https://u/mcp", "hk-rotated")
 
     assert status is Status.INSTALLED
-    remove, add = calls
-    assert remove[1:3] == ["mcp", "remove"] and remove[remove.index("--scope") + 1] == "user"
+    *removes, add = calls
+    assert {rm[rm.index("--scope") + 1] for rm in removes} == {"local", "user"}
+    assert all(rm[1:3] == ["mcp", "remove"] for rm in removes)
     assert add[1:3] == ["mcp", "add"] and add[add.index("--scope") + 1] == "user"
     assert "Authorization: Bearer hk-rotated" in add
 


### PR DESCRIPTION
Reinstall now clears the Claude `hai-agents` entry at both local and user scope before re-adding at user scope, so a stale local entry (old key/url) can't shadow the new one. Fixes the follow-up Bugbot finding on #79. Not merging, yours to review.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to CLI install ordering for Claude Code only; other MCP clients unchanged and behavior is additive cleanup before add.
> 
> **Overview**
> **Claude Code MCP reinstall** now runs **two** `claude mcp remove` calls—**local** and **user** scope—before the existing user-scoped `add`, so an old local `hai-agents` entry (stale URL/key) cannot override the freshly installed user config.
> 
> The `Client` model replaces a single optional `cli_remove_cmd` with `cli_remove_cmds` (a tuple of command tuples), and `_install_via_cli` executes every remove in sequence. The install test expects both scopes to be cleared before add.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70924fab7e9a4171cf8d513afc7b2a20fad946b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->