### PR TITLE
Print a clickable Agent View link in the CLI

### DIFF
--- a/src/hai_agents_cli/app.py
+++ b/src/hai_agents_cli/app.py
@@ -12,7 +12,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from hai_agents import Client, wait_for_session
+from hai_agents import Client, assert_request_under_limit, wait_for_session
 from hai_agents.core.api_error import ApiError
 from hai_agents.sessions import SendSessionMessagesRequestBody_UserMessage
 from hai_agents.types import PageSessionSummary
@@ -167,14 +167,16 @@ def run(
     state = _state(ctx)
     client = _client(state)
     overrides = _parse_overrides(override or [])
+    params = {
+        "agent": agent,
+        "messages": task,
+        "max_steps": max_steps,
+        "max_time_s": max_time_s,
+        "overrides": overrides or None,
+    }
     try:
-        session = client.sessions.create_session(
-            agent=agent,
-            messages=task,
-            max_steps=max_steps,
-            max_time_s=max_time_s,
-            overrides=overrides or None,
-        )
+        assert_request_under_limit(params)
+        session = client.sessions.create_session(**params)
     except Exception as exc:
         _raise_cli_error(exc)
     agent_view_url = getattr(session, "agent_view_url", None)

--- a/src/hai_agents_cli/app.py
+++ b/src/hai_agents_cli/app.py
@@ -12,7 +12,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from hai_agents import Client, run_session
+from hai_agents import Client, wait_for_session
 from hai_agents.core.api_error import ApiError
 from hai_agents.sessions import SendSessionMessagesRequestBody_UserMessage
 from hai_agents.types import PageSessionSummary
@@ -168,18 +168,23 @@ def run(
     client = _client(state)
     overrides = _parse_overrides(override or [])
     try:
-        result = run_session(
-            client,
+        session = client.sessions.create_session(
             agent=agent,
             messages=task,
             max_steps=max_steps,
             max_time_s=max_time_s,
-            timeout_seconds=max_time_s + 30.0,
             overrides=overrides or None,
         )
     except Exception as exc:
         _raise_cli_error(exc)
-    _print_run_result(result, state.json_output)
+    agent_view_url = getattr(session, "agent_view_url", None)
+    if agent_view_url and not state.json_output:
+        console.print(f"[bold]Live view:[/bold] [link={agent_view_url}]{agent_view_url}[/link]")
+    try:
+        result = wait_for_session(client, session.id, timeout_seconds=max_time_s + 30.0)
+    except Exception as exc:
+        _raise_cli_error(exc)
+    _print_run_result(result, state.json_output, agent_view_url=agent_view_url)
 
 
 @sessions_app.command("list")
@@ -202,7 +207,9 @@ def list_sessions(
 
     table = Table("ID", "Status", "Agent", "Created")
     for item in result.items:
-        table.add_row(item.id, _status_text(item.status), item.agent or "", item.created_at.isoformat())
+        url = getattr(item, "agent_view_url", None)
+        id_cell = f"[link={url}]{item.id}[/link]" if url else item.id
+        table.add_row(id_cell, _status_text(item.status), item.agent or "", item.created_at.isoformat())
     console.print(table)
 
 
@@ -380,11 +387,12 @@ def _client(state: AppState) -> Client:
         _raise_cli_error(exc)
 
 
-def _print_run_result(result, json_output: bool) -> None:
+def _print_run_result(result, json_output: bool, agent_view_url: str | None = None) -> None:
     payload = {
         "session_id": result.id,
         "status": _status_text(result.status),
         "answer": result.answer,
+        "agent_view_url": agent_view_url,
     }
     if json_output:
         _print_json(payload)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,14 +33,29 @@ def test_missing_api_key_is_clear(monkeypatch, tmp_path) -> None:
 
 
 def test_run_prints_json(monkeypatch) -> None:
-    monkeypatch.setattr(app_module, "_client", lambda state: object())
-    monkeypatch.setattr(app_module, "run_session", _fake_run_session)
+    monkeypatch.setattr(app_module, "_client", lambda state: _RunClient())
+    monkeypatch.setattr(app_module, "wait_for_session", _fake_wait_for_session)
 
     result = runner.invoke(app, ["--json", "run", "hello"], env={"HAI_API_KEY": "hk-test"})
 
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
-    assert payload == {"answer": "done", "session_id": "sess_1", "status": "completed"}
+    assert payload == {
+        "answer": "done",
+        "session_id": "sess_1",
+        "status": "completed",
+        "agent_view_url": "https://platform.example.test/agent-view/sess_1",
+    }
+
+
+def test_run_prints_live_view_link(monkeypatch) -> None:
+    monkeypatch.setattr(app_module, "_client", lambda state: _RunClient())
+    monkeypatch.setattr(app_module, "wait_for_session", _fake_wait_for_session)
+
+    result = runner.invoke(app, ["run", "hello"], env={"HAI_API_KEY": "hk-test"})
+
+    assert result.exit_code == 0, result.output
+    assert "https://platform.example.test/agent-view/sess_1" in result.output
 
 
 def test_share_session_prints_absolute_url(monkeypatch) -> None:
@@ -84,13 +99,10 @@ def test_state_missing_is_a_programming_error() -> None:
 
 def test_run_parses_overrides(monkeypatch) -> None:
     captured: dict = {}
+    client = _RunClient(capture=captured)
 
-    def _capture(client, **kwargs):
-        captured.update(kwargs)
-        return SessionRunResult(id="sess_1", status="completed", events=[], next_from_index=0, final_changes=_Answer())
-
-    monkeypatch.setattr(app_module, "_client", lambda state: object())
-    monkeypatch.setattr(app_module, "run_session", _capture)
+    monkeypatch.setattr(app_module, "_client", lambda state: client)
+    monkeypatch.setattr(app_module, "wait_for_session", _fake_wait_for_session)
 
     result = runner.invoke(
         app,
@@ -112,10 +124,28 @@ def test_run_parses_overrides(monkeypatch) -> None:
     }
 
 
-def _fake_run_session(client, **kwargs):
-    assert kwargs["messages"] == "hello"
-    assert kwargs["agent"] == "h/web-surfer-holo3-1-35b"
+def _fake_wait_for_session(client, id, **kwargs):
+    assert id == "sess_1"
     return SessionRunResult(id="sess_1", status="completed", events=[], next_from_index=0, final_changes=_Answer())
+
+
+class _RunSessions:
+    def __init__(self, capture: dict | None = None) -> None:
+        self._capture = capture
+
+    def create_session(self, **kwargs):
+        if self._capture is not None:
+            self._capture.update(kwargs)
+        return type(
+            "Session",
+            (),
+            {"id": "sess_1", "agent_view_url": "https://platform.example.test/agent-view/sess_1"},
+        )()
+
+
+class _RunClient:
+    def __init__(self, capture: dict | None = None) -> None:
+        self.sessions = _RunSessions(capture)
 
 
 class _Answer:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,6 +97,18 @@ def test_state_missing_is_a_programming_error() -> None:
         raise AssertionError("_state should fail when Typer state is missing")
 
 
+def test_run_rejects_oversized_payload_before_sending(monkeypatch) -> None:
+    captured: dict = {}
+    client = _RunClient(capture=captured)
+    monkeypatch.setattr(app_module, "_client", lambda state: client)
+
+    result = runner.invoke(app, ["run", "x" * (6 * 1024 * 1024)], env={"HAI_API_KEY": "hk-test"})
+
+    assert result.exit_code != 0
+    assert "over the" in _error_text(result)
+    assert not captured  # no HTTP call was attempted
+
+
 def test_run_parses_overrides(monkeypatch) -> None:
     captured: dict = {}
     client = _RunClient(capture=captured)


### PR DESCRIPTION
The platform's Agent View page now ships as `agent_view_url` on session responses (hcompai/agent_platform#1256); this makes the CLI show it the moment a run starts so users can watch the agent work live.

## Changes
- **cli run**: creates the session, prints `Live view:` as an OSC 8 terminal hyperlink (rich `[link=...]`), then waits for completion; `--json` payload gains `agent_view_url`; payload size still validated client-side via `assert_request_under_limit` before the HTTP request
- **cli sessions list**: ID cells become clickable links when the server provides `agent_view_url`
- **tests/test_cli.py**: run covers the link line, json payload, oversized-payload rejection, and overrides via a faked `sessions.create_session` + `wait_for_session`

Reads the field with `getattr(..., None)`, so it degrades to no link against servers that do not send it yet, and needs no SDK regen (generated models allow extra fields).

## Test
```bash
$ uv run pytest tests/test_cli.py tests/test_cli_drift.py tests/test_smoke.py -q
...............                                                          [100%]

$ uv run ruff check src/hai_agents_cli/app.py tests/test_cli.py
All checks passed!
```
(15 dots = 9 cli + 4 drift + 2 smoke, exit 0; this repo's pytest config suppresses the summary line.)

Not yet run: an end-to-end `hai run` against staging once hcompai/agent_platform#1256 deploys (`uv run hai run "find the H homepage"` should print the platform link).