### PR TITLE
chore(sdk): sync to agent_platform@f57ac85 (v0.1.7)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3156,6 +3156,18 @@
           "status": {
             "$ref": "#/components/schemas/SessionStatus"
           },
+          "agent_view_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent View Url",
+            "description": "URL of the session's Agent View page on the H Platform (live view and replay)."
+          },
           "latest_answer": {
             "title": "Latest Answer",
             "description": "The agent's most recent final answer: free-form text, or structured data when the agent runs with a custom answer format. Null until the agent first answers. Mirrors the answer streamed from the changes endpoint, surfaced here for non-interactive runs."
@@ -3394,6 +3406,18 @@
           },
           "status": {
             "$ref": "#/components/schemas/TrajectoryStatus"
+          },
+          "agent_view_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent View Url",
+            "description": "URL of the session's Agent View page on the H Platform (live view and replay)."
           },
           "first_message": {
             "anyOf": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "0.1.6"
+version = "0.1.7"
 description = "Python SDK for H Company's Agent API: autonomous agents powered by Holo."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/hai_agents/types/session.py
+++ b/src/hai_agents/types/session.py
@@ -19,6 +19,11 @@ class Session(UniversalBaseModel):
     id: str
     request: SessionRequest
     status: SessionStatus
+    agent_view_url: typing.Optional[str] = pydantic.Field(default=None)
+    """
+    URL of the session's Agent View page on the H Platform (live view and replay).
+    """
+
     latest_answer: typing.Optional[typing.Any] = pydantic.Field(default=None)
     """
     The agent's most recent final answer: free-form text, or structured data when the agent runs with a custom answer format. Null until the agent first answers. Mirrors the answer streamed from the changes endpoint, surfaced here for non-interactive runs.

--- a/src/hai_agents/types/session_summary.py
+++ b/src/hai_agents/types/session_summary.py
@@ -17,6 +17,11 @@ class SessionSummary(UniversalBaseModel):
     id: str
     agent: typing.Optional[str] = None
     status: TrajectoryStatus
+    agent_view_url: typing.Optional[str] = pydantic.Field(default=None)
+    """
+    URL of the session's Agent View page on the H Platform (live view and replay).
+    """
+
     first_message: typing.Optional[UserMessageEvent] = None
     created_at: dt.datetime
     started_at: typing.Optional[dt.datetime] = None

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "hai-agents"
-version = "0.1.5"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.1.7` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@f57ac85


<!-- CURSOR_SUMMARY -->
---

<!-- /CURSOR_SUMMARY -->
