### PR TITLE
set version to 0.1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "0.1.7"
+version = "0.1.6"
 description = "Python SDK for H Company's Agent API: autonomous agents powered by Holo."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "hai-agents"
-version = "0.1.7"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Aligns the package version with PyPI: latest published release is 0.1.5, but two pre-release bumps both moved pyproject to 0.1.7, so the next release would skip a version. Sets pyproject.toml and uv.lock to 0.1.6 ahead of the v0.1.6 release.

## Changes
- **pyproject.toml / uv.lock**: version 0.1.6

## Test
```bash
$ rg "^version" pyproject.toml
version = "0.1.6"

$ rg -A1 'name = "hai-agents"$' uv.lock | head -2
name = "hai-agents"
version = "0.1.6"
```

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version alignment; no application or dependency logic changes.
> 
> **Overview**
> Sets **`hai-agents`** package version from **0.1.7** to **0.1.6** in `pyproject.toml` and the matching `hai-agents` entry in `uv.lock`, so the next PyPI release follows **0.1.5** without skipping **0.1.6** after premature bumps on main.
> 
> No library, CLI, or dependency changes—only release metadata. Release CI still requires the git tag to match `pyproject.toml` version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24533dd700b390f992ad192b375317923e52c862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->