### PR TITLE
bump version to 0.1.7 for the custom tools release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "0.1.6"
+version = "0.1.7"
 description = "Python SDK for H Company's Agent API: autonomous agents powered by Holo."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "hai-agents"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
The v0.1.6 release reused a stale pre-existing tag pointing at a commit from before custom tools merged, so PyPI 0.1.6 shipped without them; PyPI never accepts a version re-upload, so custom tools ship as 0.1.7 built from current main.

## Changes
- **pyproject.toml / uv.lock**: version 0.1.7

## Test
```bash
$ rg "^version" pyproject.toml
version = "0.1.7"

$ uv run pytest tests
45 passed, 7 deselected in 2.76s
```

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime or dependency changes in the diff.
> 
> **Overview**
> Bumps the **hai-agents** package version from **0.1.6** to **0.1.7** so PyPI can ship a release that includes custom tools. PyPI does not allow re-uploading 0.1.6 after a bad publish tied to a stale tag.
> 
> The only edits are `version = "0.1.7"` in `pyproject.toml` and the matching `hai-agents` entry in `uv.lock`; no library or API code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4125bb389fc2eef2933bffd4a82b711b5215d7c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

