### PR TITLE
Restore spec'd const defaults on union-discriminator fields (fixes inline Browser 422)

### DIFF
--- a/src/hai_agents/types/browser.py
+++ b/src/hai_agents/types/browser.py
@@ -18,7 +18,7 @@ class Browser(UniversalBaseModel):
     Catalog identifier for this environment.
     """
 
-    kind: typing.Optional[BrowserKind] = None
+    kind: typing.Optional[BrowserKind] = "web"
     headless: typing.Optional[bool] = pydantic.Field(default=None)
     """
     Run without a visible window.

--- a/src/hai_agents/types/one_password_config.py
+++ b/src/hai_agents/types/one_password_config.py
@@ -12,7 +12,7 @@ class OnePasswordConfig(UniversalBaseModel):
     1Password vault provider config.
     """
 
-    provider: typing.Optional[OnePasswordConfigProvider] = None
+    provider: typing.Optional[OnePasswordConfigProvider] = "onepassword"
     op_vault_id: str
 
     if IS_PYDANTIC_V2:

--- a/src/hai_agents/types/tool_result_event.py
+++ b/src/hai_agents/types/tool_result_event.py
@@ -12,7 +12,7 @@ class ToolResultEvent(UniversalBaseModel):
     The client is sending back the result of a custom tool call.
     """
 
-    type: typing.Optional[ToolResultEventType] = None
+    type: typing.Optional[ToolResultEventType] = "tool_result"
     tool_call_id: str = pydantic.Field()
     """
     Id of the pending tool call this result answers.

--- a/src/hai_agents/types/user_message_event.py
+++ b/src/hai_agents/types/user_message_event.py
@@ -12,7 +12,7 @@ class UserMessageEvent(UniversalBaseModel):
     The user is sending a message to an active agent.
     """
 
-    type: typing.Optional[UserMessageEventType] = None
+    type: typing.Optional[UserMessageEventType] = "user_message"
     message: str = pydantic.Field()
     """
     Message text sent to the agent.

--- a/tests/test_spec_defaults.py
+++ b/tests/test_spec_defaults.py
@@ -1,0 +1,79 @@
+"""The OpenAPI spec's const+default discriminators must survive into the generated models.
+
+The API discriminates several tagged unions on a constant field (``Browser.kind``,
+``OnePasswordConfig.provider``, event ``type`` tags). The spec declares those fields with both
+``const`` and ``default``, but the Fern generator drops the default and emits ``= None`` — the
+serializer then omits the field entirely and the server rejects the payload with a 422
+("Unable to extract tag using discriminator 'kind'") because union discrimination runs before
+per-variant defaults are applied.
+
+These tests pin the hand-restored defaults so a future regeneration that clobbers them fails CI
+loudly instead of shipping another field-omission 422.
+"""
+
+import json
+import pathlib
+import typing
+
+import pytest
+
+import hai_agents.types as types_module
+from hai_agents.core.http_client import get_request_body
+from hai_agents.types import Browser, OnePasswordConfig, ToolResultEvent, UserMessageEvent
+
+OPENAPI_PATH = pathlib.Path(__file__).parent.parent / "openapi.json"
+
+# Schemas whose const+default field was dropped ENTIRELY by the generator (not just its default).
+# Their discriminator is carried by the per-endpoint request-body wrapper types instead
+# (e.g. SendSessionToolResultsRequestBody_Batch), so there is no model field to default.
+FIELD_DROPPED_ENTIRELY = {("ToolResultBatch", "type"), ("UserMessageBatch", "type")}
+
+MINIMAL_KWARGS: dict[str, dict[str, typing.Any]] = {
+    "Browser": {"id": "browser"},
+    "OnePasswordConfig": {"op_vault_id": "vault_1"},
+    "ToolResultEvent": {"tool_call_id": "call_1", "result": "ok"},
+    "UserMessageEvent": {"message": "hi"},
+}
+
+
+def _spec_const_defaults() -> list[tuple[str, str, typing.Any]]:
+    spec = json.loads(OPENAPI_PATH.read_text())
+    cases = []
+    for schema_name, schema in spec["components"]["schemas"].items():
+        for prop_name, prop in schema.get("properties", {}).items():
+            if isinstance(prop, dict) and "const" in prop and "default" in prop:
+                cases.append((schema_name, prop_name, prop["default"]))
+    return cases
+
+
+def test_spec_declares_the_known_discriminator_defaults():
+    """Guard the guard: if the spec stops declaring these, the drift test below would go vacuous."""
+    found = {(s, p) for s, p, _ in _spec_const_defaults()}
+    assert {("Browser", "kind"), ("OnePasswordConfig", "provider")} <= found
+
+
+@pytest.mark.parametrize("schema_name,prop_name,expected_default", _spec_const_defaults())
+def test_generated_model_honors_spec_default(schema_name, prop_name, expected_default):
+    if (schema_name, prop_name) in FIELD_DROPPED_ENTIRELY:
+        pytest.skip("field dropped from the generated model; tag carried by the request-body wrappers")
+    model = getattr(types_module, schema_name)
+    instance = model(**MINIMAL_KWARGS.get(schema_name, {}))
+    assert getattr(instance, prop_name) == expected_default, (
+        f"{schema_name}.{prop_name} should default to {expected_default!r} per the OpenAPI spec; "
+        "a regeneration probably clobbered the hand-restored default (see this file's docstring)."
+    )
+
+
+@pytest.mark.parametrize(
+    "instance,field,expected",
+    [
+        (Browser(id="browser", start_url="https://x.test"), "kind", "web"),
+        (OnePasswordConfig(op_vault_id="vault_1"), "provider", "onepassword"),
+        (ToolResultEvent(tool_call_id="call_1", result="ok"), "type", "tool_result"),
+        (UserMessageEvent(message="hi"), "type", "user_message"),
+    ],
+)
+def test_default_reaches_the_wire_body(instance, field, expected):
+    """The default must actually serialize — an attribute default that exclude-unset drops is no fix."""
+    json_body, _ = get_request_body(json=instance, data=None, request_options=None, omit=None)
+    assert json_body[field] == expected


### PR DESCRIPTION
## The bug

Found while live-testing the [agent-sdk-demo counterfeit-detection cookbook](https://github.com/hcompai/agent-sdk-demo/pull/9) against the production Agent API on 0.1.7:

```python
Browser(id="browser", headless=True, start_url="https://example.com")
```

fails session creation with:

```
422: Unable to extract tag using discriminator 'kind'
```

## Root cause

The OpenAPI spec is correct — `Browser.kind` is declared `{"const": "web", "default": "web"}` — but the Fern generator **drops the default** and emits `kind: typing.Optional[BrowserKind] = None`. The serializer omits `None` fields, so the wire payload has no discriminator, and the server's tagged-union validation runs *before* per-variant defaults apply. Every inline `Browser` built without an explicit `kind="web"` is rejected.

Four spec'd const-defaults are affected the same way:

| Schema.field | Spec default | Generated default |
| --- | --- | --- |
| `Browser.kind` | `"web"` | `None` ← the live 422 |
| `OnePasswordConfig.provider` | `"onepassword"` | `None` |
| `ToolResultEvent.type` | `"tool_result"` | `None` |
| `UserMessageEvent.type` | `"user_message"` | `None` |

(`ToolResultBatch.type` / `UserMessageBatch.type` were dropped from their models entirely; their tag is carried by the per-endpoint request-body wrapper types, so no model fix applies.)

## The fix + the regen guard

These are generated files, so a hand-patch alone would be clobbered by the next regeneration. The PR therefore does two things:

1. Restores the four defaults (`= "web"` etc., keeping the `Optional[...]` annotations).
2. Adds `tests/test_spec_defaults.py`, which **parses `openapi.json`** and asserts every `const`+`default` property is honored by its generated model *and actually reaches the wire body* (via `get_request_body` — an attribute default that an exclude-unset dump drops would be no fix). If a future regen reintroduces the drop, CI fails loudly with a message pointing here instead of shipping another field-omission 422.

The durable fix is in the Fern pipeline (the generator discarding `default` when combined with `const`); until then this keeps the published SDK matching its own spec.

## Verification

- `pytest tests -m "not integration"` — 55 passed, 2 skipped (the documented batch-model cases)
- Live-verified: with `kind="web"` present, inline-Browser sessions create and complete normally (three full cookbook runs on production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request serialization for sessions, vault config, and session events; wrong defaults could still cause API validation failures, but changes align models with the published spec and are guarded by tests.
> 
> **Overview**
> Fixes **422 discriminator errors** when clients build SDK models without explicitly setting union tag fields (e.g. inline `Browser` without `kind`).
> 
> **Model defaults:** Four Fern-generated types now use the OpenAPI **const+default** values instead of `None`: `Browser.kind` → `"web"`, `OnePasswordConfig.provider` → `"onepassword"`, `ToolResultEvent.type` → `"tool_result"`, `UserMessageEvent.type` → `"user_message"`. Previously omitted `None` fields broke tagged-union validation on the server.
> 
> **Regression guard:** New `tests/test_spec_defaults.py` walks `openapi.json` for every `const`+`default` property, asserts generated models match, and checks `get_request_body` includes those tags on the wire (so a default that serialization drops would fail CI). Batch types whose discriminator field was dropped entirely are skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb2e65889e846e02cd09a874bc5e32d918c1d9e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->