### PR TITLE
Type the tool() decorator with overloads

### DIFF
--- a/src/hai_agents/tools.py
+++ b/src/hai_agents/tools.py
@@ -43,12 +43,25 @@ def _schema_from_signature(fn: typing.Callable[..., typing.Any]) -> typing.Dict[
     return schema
 
 
+@typing.overload
+def tool(fn: typing.Callable[..., typing.Any]) -> Tool: ...
+
+
+@typing.overload
+def tool(
+    fn: None = None,
+    *,
+    name: typing.Optional[str] = None,
+    description: typing.Optional[str] = None,
+) -> typing.Callable[[typing.Callable[..., typing.Any]], Tool]: ...
+
+
 def tool(
     fn: typing.Optional[typing.Callable[..., typing.Any]] = None,
     *,
     name: typing.Optional[str] = None,
     description: typing.Optional[str] = None,
-) -> typing.Any:
+) -> typing.Union[Tool, typing.Callable[[typing.Callable[..., typing.Any]], Tool]]:
     """Wrap a function as a custom :class:`Tool` executed in your process; the input schema is derived from its signature."""
 
     def wrap(f: typing.Callable[..., typing.Any]) -> Tool:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -26,6 +26,19 @@ def test_tool_decorator_derives_schema():
     assert get_weather(city="Paris") == "Sunny in Paris (celsius)"
 
 
+def test_tool_decorator_with_args_returns_tool_and_applies_overrides():
+    # Both call forms must produce a Tool — the @typing.overload pair on tool() pins this contract
+    # for static checkers too (a bare ``-> Any`` return makes every @tool function untyped under
+    # mypy --strict's untyped-decorator rule).
+    @tool(name="weather_lookup", description="Look up the weather.")
+    def whatever(city: str) -> str:
+        return city
+
+    assert isinstance(whatever, Tool)
+    assert whatever.name == "weather_lookup"
+    assert whatever.description == "Look up the weather."
+
+
 def test_tool_without_description_raises():
     with pytest.raises(ValueError, match="needs a description"):
 
@@ -116,7 +129,9 @@ def test_post_accepts_409_without_retrying():
 
     httpx = _FakeHttpx(statuses=[409])
     client = SimpleNamespace(_client_wrapper=SimpleNamespace(httpx_client=httpx))
-    _post_tool_results(client, "sess_1", [{"type": "tool_result", "tool_call_id": "c1", "result": "", "is_error": False}])
+    _post_tool_results(
+        client, "sess_1", [{"type": "tool_result", "tool_call_id": "c1", "result": "", "is_error": False}]
+    )
     assert len(httpx.requests) == 1
     assert httpx.requests[0]["request_options"] == {"max_retries": 0}
 
@@ -126,7 +141,9 @@ def test_post_retries_transient_errors():
 
     httpx = _FakeHttpx(statuses=[500, 202])
     client = SimpleNamespace(_client_wrapper=SimpleNamespace(httpx_client=httpx))
-    _post_tool_results(client, "sess_1", [{"type": "tool_result", "tool_call_id": "c1", "result": "", "is_error": False}])
+    _post_tool_results(
+        client, "sess_1", [{"type": "tool_result", "tool_call_id": "c1", "result": "", "is_error": False}]
+    )
     assert len(httpx.requests) == 2
 
 


### PR DESCRIPTION
## The problem

`tool()` is annotated `-> typing.Any`, so under `mypy --strict` every consumer's `@tool(...)`-decorated function trips `untyped-decorator` and the decorated name degrades to `Any`. While building the [agent-sdk-demo counterfeit-detection cookbook](https://github.com/hcompai/agent-sdk-demo/pull/9) we had to carry a scoped mypy override solely for this — every strict-mode consumer of the custom-tools API will need the same workaround.

## The fix

Two `@typing.overload`s pin the real contract:

```python
@typing.overload
def tool(fn: typing.Callable[..., typing.Any]) -> Tool: ...          # bare @tool

@typing.overload
def tool(
    fn: None = None, *, name: str | None = None, description: str | None = None
) -> typing.Callable[[typing.Callable[..., typing.Any]], Tool]: ...  # @tool(name=..., description=...)
```

The implementation signature gains the matching `Union` return. Runtime behavior is unchanged — `tools.py` is hand-written (not Fern-generated), so this survives regeneration.

Also adds a test asserting the factory form returns a `Tool` and applies the `name`/`description` overrides (only the bare form was covered).

## Verification

`pytest tests -m "not integration"` — all green; `ruff check` / `ruff format --check` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing-only change to the decorator; runtime tool wrapping and schemas are unchanged.
> 
> **Overview**
> Adds **`@typing.overload`** signatures on **`tool()`** so static checkers see the real contract: bare **`@tool`** returns **`Tool`**, and **`@tool(name=..., description=...)`** returns a decorator that yields **`Tool`**. The implementation return type changes from **`typing.Any`** to a matching **`Union`**, which should stop **`mypy --strict`** from flagging **`untyped-decorator`** on decorated tool functions.
> 
> Runtime behavior is unchanged. A new test covers the parameterized decorator form (**`name`** / **`description`** overrides). Two existing tests only reformat long **`_post_tool_results`** call lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0483f525985620804f351b282378ce1d3f68ab4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->