### PR TITLE
Fix answer_schema conflict guard for inline agents with answer_format overrides

### DIFF
--- a/src/hai_agents/polling.py
+++ b/src/hai_agents/polling.py
@@ -86,11 +86,11 @@ def _attach_answer_schema(params: typing.Dict[str, typing.Any], model: typing.Ty
     if not (isinstance(model, type) and issubclass(model, pydantic.BaseModel)):
         raise TypeError(f"answer_schema must be a pydantic.BaseModel subclass, got {model!r}.")
     schema = model.model_json_schema()
+    if (params.get("overrides") or {}).get("agent.answer_format") is not None:
+        raise ValueError("answer_schema conflicts with overrides['agent.answer_format']; pass only one.")
     agent = params.get("agent")
     if isinstance(agent, str):
         overrides = dict(params.get("overrides") or {})
-        if overrides.get("agent.answer_format") is not None:
-            raise ValueError("answer_schema conflicts with overrides['agent.answer_format']; pass only one.")
         overrides["agent.answer_format"] = schema
         params["overrides"] = overrides
     elif isinstance(agent, dict):

--- a/tests/test_answer_schema.py
+++ b/tests/test_answer_schema.py
@@ -81,6 +81,10 @@ class TestSchemaInjection:
         with pytest.raises(ValueError, match="conflicts"):
             _attach_answer_schema({"agent": "h/web-surfer", "overrides": {"agent.answer_format": {}}}, JobListings)
 
+    def test_inline_agent_with_answer_format_override_conflicts(self) -> None:
+        with pytest.raises(ValueError, match="conflicts"):
+            _attach_answer_schema({"agent": {"name": "a"}, "overrides": {"agent.answer_format": {}}}, JobListings)
+
     def test_non_model_schema_rejected(self) -> None:
         with pytest.raises(TypeError, match="BaseModel"):
             _attach_answer_schema({"agent": "h/web-surfer"}, dict)


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation-order fix in session helper code with a targeted unit test; no runtime behavior change for valid call patterns.
> 
> **Overview**
> **Fixes a gap in `_attach_answer_schema` conflict detection** when callers use an **inline dict agent** together with `overrides['agent.answer_format']`.
> 
> The check that rejects combining `answer_schema` with an existing `overrides['agent.answer_format']` is moved **before** the agent-type branches, so it applies whether `agent` is a catalog string, inline dict, or pydantic model. Previously that override conflict was only enforced on the string-agent path, so inline agents could slip through with both sources of `answer_format`.
> 
> A test covers the inline-agent + override case and expects a `ValueError` with message `conflicts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4aef12db62f95bd27f5c20874152b076b4a7e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->