### PR TITLE
Add CLI inspection commands (sessions status/events/watch, agents, skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install "hai-agents[cli]"
 Requires Python 3.10 or newer. Grab an API key at [portal.hcompany.ai](https://portal.hcompany.ai) and export it:
 
 ```bash
-export H_API_KEY=hk-...
+export HAI_API_KEY=hk-...
 ```
 
 ## Quickstart
@@ -52,7 +52,7 @@ Launch the built-in `h/web-surfer-holo3-1-35b` agent, which ships with its own b
 ```python
 from hai_agents import Client, run_session
 
-client = Client()  # reads H_API_KEY from the environment
+client = Client()  # reads HAI_API_KEY from the environment
 
 result = run_session(
     client,

--- a/src/hai_agents_cli/app.py
+++ b/src/hai_agents_cli/app.py
@@ -62,9 +62,7 @@ class AppState:
 @app.callback()
 def configure(
     ctx: typer.Context,
-    api_key: str | None = typer.Option(
-        None, "--api-key", help="API key. Defaults to HAI_API_KEY."
-    ),
+    api_key: str | None = typer.Option(None, "--api-key", help="API key. Defaults to HAI_API_KEY."),
     base_url: str | None = typer.Option(None, "--base-url", help="Override the Agent Platform base URL."),
     json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON."),
 ) -> None:
@@ -341,21 +339,28 @@ def watch(
     from_index = 0
     deadline = time.monotonic() + timeout
     while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            _raise_cli_error(TimeoutError(f"Session {session_id} did not settle within {timeout}s."))
         try:
             changes = client.sessions.get_session_changes(
-                session_id, from_index=from_index, include_events=True, wait_for_seconds=20
+                session_id, from_index=from_index, include_events=True, wait_for_seconds=min(20, int(remaining))
             )
             for event in (changes.new_events if changes else None) or []:
-                console.print(_event_line(from_index, event))
+                if state.json_output:
+                    print(json.dumps(to_jsonable(event), sort_keys=True))
+                else:
+                    console.print(_event_line(from_index, event))
                 from_index += 1
             current = client.sessions.get_session_status(session_id)
         except Exception as exc:
             _raise_cli_error(exc)
         if is_settled_session_status(current.status):
-            console.print(f"[bold]Status:[/bold] {_status_text(current.status)}")
+            if state.json_output:
+                print(json.dumps(to_jsonable(current), sort_keys=True))
+            else:
+                console.print(f"[bold]Status:[/bold] {_status_text(current.status)}")
             return
-        if time.monotonic() >= deadline:
-            _raise_cli_error(TimeoutError(f"Session {session_id} did not settle within {timeout}s."))
 
 
 @agents_app.command("list")

--- a/src/hai_agents_cli/app.py
+++ b/src/hai_agents_cli/app.py
@@ -63,7 +63,7 @@ class AppState:
 def configure(
     ctx: typer.Context,
     api_key: str | None = typer.Option(
-        None, "--api-key", help="API key. Defaults to HAI_API_KEY (or legacy H_API_KEY)."
+        None, "--api-key", help="API key. Defaults to HAI_API_KEY."
     ),
     base_url: str | None = typer.Option(None, "--base-url", help="Override the Agent Platform base URL."),
     json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON."),

--- a/src/hai_agents_cli/app.py
+++ b/src/hai_agents_cli/app.py
@@ -358,7 +358,7 @@ def watch(
                 final = client.sessions.get_session_changes(
                     session_id, from_index=0, include_events=False, wait_for_seconds=0
                 )
-                _print_watch_result(state, current.status, final)
+                _print_watch_result(state, current, final)
                 return
         except Exception as exc:
             _raise_cli_error(exc)
@@ -579,12 +579,14 @@ def _print_json(value) -> None:
     print(json.dumps(to_jsonable(value), indent=2, sort_keys=True))
 
 
-def _print_watch_result(state: AppState, status, final) -> None:
+def _print_watch_result(state: AppState, status_result, final) -> None:
     if state.json_output:
-        payload = final if final is not None else {"status": _status_text(status)}
-        print(json.dumps(to_jsonable(payload), sort_keys=True))
+        print(json.dumps(to_jsonable(final if final is not None else status_result), sort_keys=True))
         return
-    console.print(f"[bold]Status:[/bold] {_status_text(status)}")
+    console.print(f"[bold]Status:[/bold] {_status_text(status_result.status)}")
+    error = status_result.error or (final.error if final is not None else None)
+    if error:
+        console.print(f"[bold]Error:[/bold] {error}")
     answer = final.answer if final is not None else None
     if answer is not None:
         console.print(answer)

--- a/src/hai_agents_cli/app.py
+++ b/src/hai_agents_cli/app.py
@@ -353,14 +353,15 @@ def watch(
                     console.print(_event_line(from_index, event))
                 from_index += 1
             current = client.sessions.get_session_status(session_id)
+            if is_settled_session_status(current.status):
+                # The terminal answer lives on /changes, not /status.
+                final = client.sessions.get_session_changes(
+                    session_id, from_index=0, include_events=False, wait_for_seconds=0
+                )
+                _print_watch_result(state, current.status, final)
+                return
         except Exception as exc:
             _raise_cli_error(exc)
-        if is_settled_session_status(current.status):
-            if state.json_output:
-                print(json.dumps(to_jsonable(current), sort_keys=True))
-            else:
-                console.print(f"[bold]Status:[/bold] {_status_text(current.status)}")
-            return
 
 
 @agents_app.command("list")
@@ -576,6 +577,17 @@ def _print_ack(action: str, json_output: bool) -> None:
 def _print_json(value) -> None:
     # Emit raw JSON to stdout; rich's Console would soft-wrap and corrupt long values.
     print(json.dumps(to_jsonable(value), indent=2, sort_keys=True))
+
+
+def _print_watch_result(state: AppState, status, final) -> None:
+    if state.json_output:
+        payload = final if final is not None else {"status": _status_text(status)}
+        print(json.dumps(to_jsonable(payload), sort_keys=True))
+        return
+    console.print(f"[bold]Status:[/bold] {_status_text(status)}")
+    answer = final.answer if final is not None else None
+    if answer is not None:
+        console.print(answer)
 
 
 def _status_text(status) -> str:

--- a/src/hai_agents_cli/app.py
+++ b/src/hai_agents_cli/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import socket
 import sys
+import time
 from dataclasses import dataclass
 from typing import Any, NoReturn
 
@@ -12,7 +13,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from hai_agents import Client, assert_request_under_limit, wait_for_session
+from hai_agents import Client, assert_request_under_limit, is_settled_session_status, wait_for_session
 from hai_agents.core.api_error import ApiError
 from hai_agents.sessions import SendSessionMessagesRequestBody_UserMessage
 from hai_agents.types import PageSessionSummary
@@ -46,6 +47,8 @@ app = typer.Typer(
     rich_markup_mode=None,
 )
 sessions_app = typer.Typer(no_args_is_help=True, help="Inspect and steer sessions.")
+agents_app = typer.Typer(no_args_is_help=True, help="Browse available agents.")
+skills_app = typer.Typer(no_args_is_help=True, help="Browse available skills.")
 mcp_app = typer.Typer(no_args_is_help=True, help="Manage the hai-agents MCP server.")
 
 
@@ -59,7 +62,9 @@ class AppState:
 @app.callback()
 def configure(
     ctx: typer.Context,
-    api_key: str | None = typer.Option(None, "--api-key", help="API key. Defaults to HAI_API_KEY or H_API_KEY."),
+    api_key: str | None = typer.Option(
+        None, "--api-key", help="API key. Defaults to HAI_API_KEY (or legacy H_API_KEY)."
+    ),
     base_url: str | None = typer.Option(None, "--base-url", help="Override the Agent Platform base URL."),
     json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON."),
 ) -> None:
@@ -276,6 +281,155 @@ def share(ctx: typer.Context, session_id: str = typer.Argument(...)) -> None:
         print(share_url)
 
 
+@sessions_app.command("status")
+def status(ctx: typer.Context, session_id: str = typer.Argument(...)) -> None:
+    """Show a session's live status, step count, and error if any."""
+    state = _state(ctx)
+    client = _client(state)
+    try:
+        result = client.sessions.get_session_status(session_id)
+    except Exception as exc:
+        _raise_cli_error(exc)
+    if state.json_output:
+        _print_json(result)
+        return
+    table = Table("Field", "Value", show_header=False)
+    table.add_row("Status", _status_text(result.status))
+    if result.steps is not None:
+        table.add_row("Steps", str(result.steps))
+    if result.error:
+        table.add_row("Error", result.error)
+    console.print(table)
+
+
+@sessions_app.command("events")
+def events(
+    ctx: typer.Context,
+    session_id: str = typer.Argument(...),
+    from_index: int = typer.Option(0, "--from-index", min=0, help="Skip events before this index."),
+    wait: int = typer.Option(0, "--wait", min=0, max=60, help="Long-poll up to N seconds for new events."),
+) -> None:
+    """Print a session's trajectory events from an index."""
+    state = _state(ctx)
+    client = _client(state)
+    try:
+        changes = client.sessions.get_session_changes(
+            session_id, from_index=from_index, include_events=True, wait_for_seconds=wait
+        )
+    except Exception as exc:
+        _raise_cli_error(exc)
+    new_events = (changes.new_events if changes else None) or []
+    if state.json_output:
+        _print_json(new_events)
+        return
+    if not new_events:
+        console.print("[dim]No new events.[/dim]")
+        return
+    for offset, event in enumerate(new_events):
+        console.print(_event_line(from_index + offset, event))
+
+
+@sessions_app.command("watch")
+def watch(
+    ctx: typer.Context,
+    session_id: str = typer.Argument(...),
+    timeout: float = typer.Option(300.0, "--timeout", min=1.0, help="Stop watching after N seconds."),
+) -> None:
+    """Stream a session's events live until it settles."""
+    state = _state(ctx)
+    client = _client(state)
+    from_index = 0
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            changes = client.sessions.get_session_changes(
+                session_id, from_index=from_index, include_events=True, wait_for_seconds=20
+            )
+            for event in (changes.new_events if changes else None) or []:
+                console.print(_event_line(from_index, event))
+                from_index += 1
+            current = client.sessions.get_session_status(session_id)
+        except Exception as exc:
+            _raise_cli_error(exc)
+        if is_settled_session_status(current.status):
+            console.print(f"[bold]Status:[/bold] {_status_text(current.status)}")
+            return
+        if time.monotonic() >= deadline:
+            _raise_cli_error(TimeoutError(f"Session {session_id} did not settle within {timeout}s."))
+
+
+@agents_app.command("list")
+def list_agents_command(
+    ctx: typer.Context,
+    search: str | None = typer.Option(None, "--search", help="Match on agent name or description."),
+    page: int = typer.Option(1, "--page", min=1),
+    size: int = typer.Option(20, "--size", min=1, max=100),
+) -> None:
+    """List reserved and org agents."""
+    state = _state(ctx)
+    client = _client(state)
+    try:
+        result = client.agents.list_agents(search=search, page=page, size=size)
+    except Exception as exc:
+        _raise_cli_error(exc)
+    if state.json_output:
+        _print_json(result)
+        return
+    table = Table("Name", "Description")
+    for item in result.items:
+        table.add_row(item.name, _truncate(item.description))
+    console.print(table)
+
+
+@agents_app.command("get")
+def get_agent_command(
+    ctx: typer.Context,
+    agent_name: str = typer.Argument(...),
+    resolve: bool = typer.Option(False, "--resolve", help="Resolve inherited fields."),
+) -> None:
+    """Fetch a single agent definition."""
+    client = _client(_state(ctx))
+    try:
+        result = client.agents.get_agent(agent_name, resolve=resolve)
+    except Exception as exc:
+        _raise_cli_error(exc)
+    _print_json(result)
+
+
+@skills_app.command("list")
+def list_skills_command(
+    ctx: typer.Context,
+    search: str | None = typer.Option(None, "--search", help="Match on skill name or description."),
+    page: int = typer.Option(1, "--page", min=1),
+    size: int = typer.Option(20, "--size", min=1, max=100),
+) -> None:
+    """List available skills."""
+    state = _state(ctx)
+    client = _client(state)
+    try:
+        result = client.skills.list_skills(search=search, page=page, size=size)
+    except Exception as exc:
+        _raise_cli_error(exc)
+    if state.json_output:
+        _print_json(result)
+        return
+    table = Table("Name", "Description")
+    for item in result.items:
+        table.add_row(item.name, _truncate(item.description))
+    console.print(table)
+
+
+@skills_app.command("get")
+def get_skill_command(ctx: typer.Context, name: str = typer.Argument(...)) -> None:
+    """Fetch a single skill definition."""
+    client = _client(_state(ctx))
+    try:
+        result = client.skills.get_skill(name)
+    except Exception as exc:
+        _raise_cli_error(exc)
+    _print_json(result)
+
+
 @mcp_app.command("install")
 def mcp_install(
     ctx: typer.Context,
@@ -369,6 +523,8 @@ def _print_mcp_results(results: list[dict], server_url: str, json_output: bool) 
 
 
 app.add_typer(sessions_app, name="sessions")
+app.add_typer(agents_app, name="agents")
+app.add_typer(skills_app, name="skills")
 app.add_typer(mcp_app, name="mcp")
 
 
@@ -419,6 +575,19 @@ def _print_json(value) -> None:
 
 def _status_text(status) -> str:
     return str(status)
+
+
+def _truncate(text: str | None, limit: int = 80) -> str:
+    if not text:
+        return ""
+    return text if len(text) <= limit else text[: limit - 1] + "..."
+
+
+def _event_line(index: int, event) -> str:
+    event_type = getattr(event, "type", "Event")
+    data = getattr(event, "data", None)
+    detail = _truncate(json.dumps(to_jsonable(data), sort_keys=True), 120) if data is not None else ""
+    return f"[dim]{index:>4}[/dim] [cyan]{event_type}[/cyan]" + (f"  {detail}" if detail else "")
 
 
 def _raise_cli_error(exc: Exception) -> NoReturn:

--- a/src/hai_agents_common/credentials.py
+++ b/src/hai_agents_common/credentials.py
@@ -14,10 +14,8 @@ from hai_agents import AsyncClient, Client
 
 ApiKey = str | Callable[[], str]
 
-# HAI_API_KEY is canonical; H_API_KEY stays accepted as a fallback for older setups.
 API_KEY_VAR = "HAI_API_KEY"
-API_KEY_ENV_VARS = (API_KEY_VAR, "H_API_KEY")
-BASE_URL_ENV_VARS = ("HAI_API_BASE_URL", "HAI_BASE_URL", "H_API_BASE_URL")
+BASE_URL_VAR = "HAI_API_BASE_URL"
 
 PORTAL_BASE = "https://portal.production.hcompany.ai"
 
@@ -32,21 +30,20 @@ def portal_base() -> str:
 
 def current_api_key(explicit: ApiKey | None = None) -> ApiKey | None:
     """Resolved API key, or None if none is configured."""
-    return explicit or _lookup(API_KEY_ENV_VARS)
+    return explicit or _lookup(API_KEY_VAR)
 
 
 def resolve_api_key(explicit: ApiKey | None = None) -> ApiKey:
     """Resolved API key, or raise with guidance if none is configured."""
     key = current_api_key(explicit)
     if not key:
-        env_names = " or ".join(API_KEY_ENV_VARS)
-        raise RuntimeError(f"No API key found. Run `hai login`, set {env_names}, or pass --api-key.")
+        raise RuntimeError(f"No API key found. Run `hai login`, set {API_KEY_VAR}, or pass --api-key.")
     return key
 
 
 def resolve_base_url(explicit: str | None = None) -> str | None:
     """Resolved base URL override, or None to use the SDK default."""
-    return explicit or _lookup(BASE_URL_ENV_VARS)
+    return explicit or _lookup(BASE_URL_VAR)
 
 
 def make_client(api_key: ApiKey | None = None, base_url: str | None = None) -> Client:
@@ -80,24 +77,21 @@ def save_api_key(key: str) -> Path:
 
 
 def clear_api_key() -> Path | None:
-    """Remove the API key (and legacy aliases) from the global `.env` and the process env. Idempotent."""
-    for name in API_KEY_ENV_VARS:
-        os.environ.pop(name, None)
+    """Remove the API key from the global `.env` and the process env. Idempotent."""
+    os.environ.pop(API_KEY_VAR, None)
     if not GLOBAL_ENV_PATH.exists():
         return None
-    for name in API_KEY_ENV_VARS:
-        with contextlib.suppress(KeyError):
-            unset_key(str(GLOBAL_ENV_PATH), name)
+    with contextlib.suppress(KeyError):
+        unset_key(str(GLOBAL_ENV_PATH), API_KEY_VAR)
     return GLOBAL_ENV_PATH
 
 
 def source() -> str | None:
     """Where the resolved credential comes from (`environment` or a file path), for `hai whoami`."""
-    for name in API_KEY_ENV_VARS:
-        if os.environ.get(name):
-            return "environment"
+    if os.environ.get(API_KEY_VAR):
+        return "environment"
     for path in _env_paths():
-        if path.exists() and any(dotenv_values(path).get(name) for name in API_KEY_ENV_VARS):
+        if path.exists() and dotenv_values(path).get(API_KEY_VAR):
             return str(path)
     return None
 
@@ -115,15 +109,13 @@ def _env_paths() -> tuple[Path, ...]:
     return (LOCAL_ENV_PATH, GLOBAL_ENV_PATH)
 
 
-def _lookup(names: tuple[str, ...]) -> str | None:
-    for name in names:
-        if os.environ.get(name):
-            return os.environ[name]
+def _lookup(name: str) -> str | None:
+    if os.environ.get(name):
+        return os.environ[name]
     for path in _env_paths():
         if not path.exists():
             continue
-        values = dotenv_values(path)
-        for name in names:
-            if values.get(name):
-                return values[name]
+        value = dotenv_values(path).get(name)
+        if value:
+            return value
     return None

--- a/src/hai_agents_common/credentials.py
+++ b/src/hai_agents_common/credentials.py
@@ -14,6 +14,7 @@ from hai_agents import AsyncClient, Client
 
 ApiKey = str | Callable[[], str]
 
+# HAI_API_KEY is canonical; H_API_KEY stays accepted as a fallback for older setups.
 API_KEY_VAR = "HAI_API_KEY"
 API_KEY_ENV_VARS = (API_KEY_VAR, "H_API_KEY")
 BASE_URL_ENV_VARS = ("HAI_API_BASE_URL", "HAI_BASE_URL", "H_API_BASE_URL")
@@ -79,12 +80,14 @@ def save_api_key(key: str) -> Path:
 
 
 def clear_api_key() -> Path | None:
-    """Remove the API key from the global `.env` and the process env. Idempotent."""
-    os.environ.pop(API_KEY_VAR, None)
+    """Remove the API key (and legacy aliases) from the global `.env` and the process env. Idempotent."""
+    for name in API_KEY_ENV_VARS:
+        os.environ.pop(name, None)
     if not GLOBAL_ENV_PATH.exists():
         return None
-    with contextlib.suppress(KeyError):
-        unset_key(str(GLOBAL_ENV_PATH), API_KEY_VAR)
+    for name in API_KEY_ENV_VARS:
+        with contextlib.suppress(KeyError):
+            unset_key(str(GLOBAL_ENV_PATH), name)
     return GLOBAL_ENV_PATH
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,6 @@ def test_help_renders_h_glyph() -> None:
 
 def test_missing_api_key_is_clear(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("HAI_API_KEY", raising=False)
-    monkeypatch.delenv("H_API_KEY", raising=False)
     monkeypatch.setattr(credentials, "LOCAL_ENV_PATH", tmp_path / "local.env")
     monkeypatch.setattr(credentials, "GLOBAL_ENV_PATH", tmp_path / "global.env")
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -35,7 +35,14 @@ def test_local_dotenv_overrides_global():
     assert credentials.source() == str(credentials.LOCAL_ENV_PATH)
 
 
-def test_h_api_key_is_a_fallback(monkeypatch):
+def test_canonical_key_beats_legacy_alias(monkeypatch):
+    monkeypatch.setenv("H_API_KEY", "hk-legacy")
+    monkeypatch.setenv("HAI_API_KEY", "hk-canonical")
+
+    assert credentials.resolve_api_key() == "hk-canonical"
+
+
+def test_legacy_h_api_key_still_accepted(monkeypatch):
     monkeypatch.setenv("H_API_KEY", "hk-legacy")
 
     assert credentials.resolve_api_key() == "hk-legacy"
@@ -52,7 +59,7 @@ def test_save_then_clear_roundtrip(monkeypatch):
     assert path == credentials.GLOBAL_ENV_PATH
     assert "hk-minted" in credentials.GLOBAL_ENV_PATH.read_text()
 
-    monkeypatch.delenv("HAI_API_KEY", raising=False)  # forget the process-env write
+    monkeypatch.delenv(credentials.API_KEY_VAR, raising=False)  # forget the process-env write
     assert credentials.resolve_api_key() == "hk-minted"
 
     credentials.clear_api_key()

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -14,7 +14,6 @@ runner = CliRunner()
 def isolated_env(tmp_path, monkeypatch):
     """Point credential resolution at empty temp files and a clean environment."""
     monkeypatch.delenv("HAI_API_KEY", raising=False)
-    monkeypatch.delenv("H_API_KEY", raising=False)
     monkeypatch.setattr(credentials, "LOCAL_ENV_PATH", tmp_path / "local.env")
     monkeypatch.setattr(credentials, "GLOBAL_ENV_PATH", tmp_path / "global.env")
 
@@ -33,19 +32,6 @@ def test_local_dotenv_overrides_global():
 
     assert credentials.resolve_api_key() == "hk-local"
     assert credentials.source() == str(credentials.LOCAL_ENV_PATH)
-
-
-def test_canonical_key_beats_legacy_alias(monkeypatch):
-    monkeypatch.setenv("H_API_KEY", "hk-legacy")
-    monkeypatch.setenv("HAI_API_KEY", "hk-canonical")
-
-    assert credentials.resolve_api_key() == "hk-canonical"
-
-
-def test_legacy_h_api_key_still_accepted(monkeypatch):
-    monkeypatch.setenv("H_API_KEY", "hk-legacy")
-
-    assert credentials.resolve_api_key() == "hk-legacy"
 
 
 def test_missing_key_raises_with_guidance():

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -95,7 +95,6 @@ def test_install_requires_api_key(monkeypatch, tmp_path) -> None:
     from hai_agents_common import credentials
 
     monkeypatch.delenv("HAI_API_KEY", raising=False)
-    monkeypatch.delenv("H_API_KEY", raising=False)
     monkeypatch.setattr(credentials, "LOCAL_ENV_PATH", tmp_path / "local.env")
     monkeypatch.setattr(credentials, "GLOBAL_ENV_PATH", tmp_path / "global.env")
 


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removing legacy env var fallbacks can break existing setups still using `H_API_KEY`; new watch/events paths depend on session API long-polling behavior.
> 
> **Overview**
> Adds **`hai sessions status`**, **`events`** (with `--from-index` and long-poll **`--wait`**), and **`watch`** (streams trajectory events until the session settles, then prints status/error/answer from `/changes`). New **`hai agents`** and **`hai skills`** subcommands support **`list`** (search/pagination tables or `--json`) and **`get`** for full definitions.
> 
> Credential resolution is narrowed to **`HAI_API_KEY`** and **`HAI_API_BASE_URL`** only—legacy **`H_API_KEY`** / alternate base URL env names are removed from lookup, CLI help, and README quickstart. Tests drop the legacy-key fallback case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c770533fe3644c175040e96f0f56f5508a70f60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->