### PR TITLE
Post v2 tool results in the kind/tool_req shape

### DIFF
--- a/src/hai_agents/polling.py
+++ b/src/hai_agents/polling.py
@@ -196,11 +196,21 @@ def _json_safe(value: typing.Any) -> typing.Any:
         return str(value)
 
 
+def _tool_result_payload(
+    call: typing.Dict[str, typing.Any], result: typing.Any, is_error: bool
+) -> typing.Dict[str, typing.Any]:
+    """Shape one settled call as a SendToolResults event: ``error_event`` on failure, else ``tool_result``."""
+    tool_req = {"tool_name": call.get("tool_name", ""), "args": call.get("args") or {}, "id": call.get("id")}
+    if is_error:
+        return {"kind": "error_event", "error": str(result), "origin": "custom_tools", "tool_req": tool_req}
+    return {"kind": "tool_result", "tool_req": tool_req, "result": _json_safe(result)}
+
+
 def _execute_tool_call(
     tools_by_name: typing.Mapping[str, Tool], call: typing.Dict[str, typing.Any]
 ) -> typing.Dict[str, typing.Any]:
     """Run one pending call locally and shape the ``tool_result`` payload."""
-    name = call.get("name", "")
+    name = call.get("tool_name", "")
     local_tool = tools_by_name.get(name)
     result: typing.Any
     is_error = True
@@ -208,14 +218,14 @@ def _execute_tool_call(
         result = f"Tool {name!r} is not registered with this client."
     else:
         try:
-            result = local_tool.fn(**(call.get("arguments") or {}))
+            result = local_tool.fn(**(call.get("args") or {}))
             if inspect.isawaitable(result):
                 result = _run_awaitable(result)
         except Exception as exc:
             result = f"{type(exc).__name__}: {exc}"
         else:
             is_error = False
-    return {"type": "tool_result", "tool_call_id": call["id"], "result": _json_safe(result), "is_error": is_error}
+    return _tool_result_payload(call, result, is_error)
 
 
 async def _await_result(value: typing.Awaitable[typing.Any]) -> typing.Any:
@@ -236,7 +246,7 @@ async def _async_execute_tool_call(
     tools_by_name: typing.Mapping[str, Tool], call: typing.Dict[str, typing.Any]
 ) -> typing.Dict[str, typing.Any]:
     """Async version of ``_execute_tool_call``; awaits coroutine tools."""
-    name = call.get("name", "")
+    name = call.get("tool_name", "")
     local_tool = tools_by_name.get(name)
     result: typing.Any
     is_error = True
@@ -244,14 +254,14 @@ async def _async_execute_tool_call(
         result = f"Tool {name!r} is not registered with this client."
     else:
         try:
-            result = local_tool.fn(**(call.get("arguments") or {}))
+            result = local_tool.fn(**(call.get("args") or {}))
             if inspect.isawaitable(result):
                 result = await result
         except Exception as exc:
             result = f"{type(exc).__name__}: {exc}"
         else:
             is_error = False
-    return {"type": "tool_result", "tool_call_id": call["id"], "result": _json_safe(result), "is_error": is_error}
+    return _tool_result_payload(call, result, is_error)
 
 
 def _tool_results_body(results: typing.List[typing.Dict[str, typing.Any]]) -> typing.Dict[str, typing.Any]:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -102,7 +102,7 @@ def test_run_session_dispatches_pending_calls_and_posts_results():
     sessions = _FakeSessions(
         polls=[
             (
-                _awaiting_changes({"id": "c1", "name": "get_weather", "arguments": {"city": "Paris"}}),
+                _awaiting_changes({"id": "c1", "tool_name": "get_weather", "args": {"city": "Paris"}}),
                 "awaiting_tool_results",
             ),
             (None, "completed"),
@@ -116,10 +116,9 @@ def test_run_session_dispatches_pending_calls_and_posts_results():
     assert sessions.created_with["overrides"]["agent.tools"] == [get_weather.definition()]
     assert [r["path"] for r in httpx.requests] == ["api/v2/sessions/sess_1/tool_results"]
     assert httpx.requests[0]["json"] == {
-        "type": "tool_result",
-        "tool_call_id": "c1",
+        "kind": "tool_result",
+        "tool_req": {"tool_name": "get_weather", "args": {"city": "Paris"}, "id": "c1"},
         "result": "Sunny in Paris (celsius)",
-        "is_error": False,
     }
     assert result.status == "completed"
 
@@ -130,7 +129,9 @@ def test_post_accepts_409_without_retrying():
     httpx = _FakeHttpx(statuses=[409])
     client = SimpleNamespace(_client_wrapper=SimpleNamespace(httpx_client=httpx))
     _post_tool_results(
-        client, "sess_1", [{"type": "tool_result", "tool_call_id": "c1", "result": "", "is_error": False}]
+        client,
+        "sess_1",
+        [{"kind": "tool_result", "tool_req": {"tool_name": "t", "args": {}, "id": "c1"}, "result": ""}],
     )
     assert len(httpx.requests) == 1
     assert httpx.requests[0]["request_options"] == {"max_retries": 0}
@@ -142,7 +143,9 @@ def test_post_retries_transient_errors():
     httpx = _FakeHttpx(statuses=[500, 202])
     client = SimpleNamespace(_client_wrapper=SimpleNamespace(httpx_client=httpx))
     _post_tool_results(
-        client, "sess_1", [{"type": "tool_result", "tool_call_id": "c1", "result": "", "is_error": False}]
+        client,
+        "sess_1",
+        [{"kind": "tool_result", "tool_req": {"tool_name": "t", "args": {}, "id": "c1"}, "result": ""}],
     )
     assert len(httpx.requests) == 2
 
@@ -154,7 +157,7 @@ def test_dispatch_reports_tool_exceptions_as_errors():
 
     sessions = _FakeSessions(
         polls=[
-            (_awaiting_changes({"id": "c1", "name": "broken", "arguments": {}}), "awaiting_tool_results"),
+            (_awaiting_changes({"id": "c1", "tool_name": "broken", "args": {}}), "awaiting_tool_results"),
             (None, "completed"),
         ]
     )
@@ -164,10 +167,10 @@ def test_dispatch_reports_tool_exceptions_as_errors():
     run_session(client, agent="h/researcher", tools=[broken])
 
     assert httpx.requests[0]["json"] == {
-        "type": "tool_result",
-        "tool_call_id": "c1",
-        "result": "RuntimeError: boom",
-        "is_error": True,
+        "kind": "error_event",
+        "error": "RuntimeError: boom",
+        "origin": "custom_tools",
+        "tool_req": {"tool_name": "broken", "args": {}, "id": "c1"},
     }
 
 
@@ -178,7 +181,7 @@ def test_sync_path_awaits_async_tools():
 
     sessions = _FakeSessions(
         polls=[
-            (_awaiting_changes({"id": "c1", "name": "lookup", "arguments": {"key": "k"}}), "awaiting_tool_results"),
+            (_awaiting_changes({"id": "c1", "tool_name": "lookup", "args": {"key": "k"}}), "awaiting_tool_results"),
             (None, "completed"),
         ]
     )
@@ -188,7 +191,7 @@ def test_sync_path_awaits_async_tools():
     run_session(client, agent="h/researcher", tools=[lookup])
 
     assert httpx.requests[0]["json"]["result"] == "value:k"
-    assert httpx.requests[0]["json"]["is_error"] is False
+    assert httpx.requests[0]["json"]["kind"] == "tool_result"
 
 
 def test_settled_and_replayed_calls_are_not_re_executed():
@@ -197,8 +200,8 @@ def test_settled_and_replayed_calls_are_not_re_executed():
         data={
             "state": "awaiting_tool_results",
             "pending_tool_calls": [
-                {"id": "c1", "name": "get_weather", "arguments": {"city": "Paris"}},
-                {"id": "c2", "name": "get_weather", "arguments": {"city": "Tokyo"}},
+                {"id": "c1", "tool_name": "get_weather", "args": {"city": "Paris"}},
+                {"id": "c2", "tool_name": "get_weather", "args": {"city": "Tokyo"}},
             ],
         },
     )
@@ -206,7 +209,7 @@ def test_settled_and_replayed_calls_are_not_re_executed():
         type="ActiveStateChangeEvent",
         data={
             "state": "awaiting_tool_results",
-            "pending_tool_calls": [{"id": "c2", "name": "get_weather", "arguments": {"city": "Tokyo"}}],
+            "pending_tool_calls": [{"id": "c2", "tool_name": "get_weather", "args": {"city": "Tokyo"}}],
         },
     )
     changes = SimpleNamespace(new_events=[stale, refreshed], answer=None)
@@ -217,7 +220,7 @@ def test_settled_and_replayed_calls_are_not_re_executed():
     run_session(client, agent="h/researcher", tools=[get_weather])
 
     assert len(httpx.requests) == 1
-    assert httpx.requests[0]["json"]["tool_call_id"] == "c2"
+    assert httpx.requests[0]["json"]["tool_req"]["id"] == "c2"
 
 
 def test_async_tool_dispatch_inside_running_loop():
@@ -226,10 +229,14 @@ def test_async_tool_dispatch_inside_running_loop():
         return f"value:{key}"
 
     async def main():
-        return _execute_tool_call({"lookup": lookup}, {"id": "c1", "name": "lookup", "arguments": {"key": "k"}})
+        return _execute_tool_call({"lookup": lookup}, {"id": "c1", "tool_name": "lookup", "args": {"key": "k"}})
 
     payload = asyncio.run(main())
-    assert payload == {"type": "tool_result", "tool_call_id": "c1", "result": "value:k", "is_error": False}
+    assert payload == {
+        "kind": "tool_result",
+        "tool_req": {"tool_name": "lookup", "args": {"key": "k"}, "id": "c1"},
+        "result": "value:k",
+    }
 
 
 def test_wait_joining_past_advertisement_recovers_pending():
@@ -239,7 +246,7 @@ def test_wait_joining_past_advertisement_recovers_pending():
 
         def get_session_changes(self, id, *, from_index, limit, include_events, wait_for_seconds):
             if from_index == 0:
-                return _awaiting_changes({"id": "c1", "name": "get_weather", "arguments": {"city": "Paris"}})
+                return _awaiting_changes({"id": "c1", "tool_name": "get_weather", "args": {"city": "Paris"}})
             return None
 
         def get_session_status(self, id):
@@ -250,7 +257,7 @@ def test_wait_joining_past_advertisement_recovers_pending():
 
     result = wait_for_session(client, id="sess_1", from_index=9, tools=[get_weather])
 
-    assert [r["json"]["tool_call_id"] for r in httpx.requests] == ["c1"]
+    assert [r["json"]["tool_req"]["id"] for r in httpx.requests] == ["c1"]
     assert result.status == "completed"
 
 
@@ -259,7 +266,7 @@ def test_no_dispatch_when_status_left_awaiting():
         type="ActiveStateChangeEvent",
         data={
             "state": "awaiting_tool_results",
-            "pending_tool_calls": [{"id": "c1", "name": "get_weather", "arguments": {"city": "Paris"}}],
+            "pending_tool_calls": [{"id": "c1", "tool_name": "get_weather", "args": {"city": "Paris"}}],
         },
     )
     changes = SimpleNamespace(new_events=[resumed], answer=None)


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the request body contract for session tool results and how pending calls are parsed; any mismatch with the live API would break custom-tool sessions.
> 
> **Overview**
> Aligns the custom-tool dispatch loop with the **v2 `SendToolResults` wire format** for `POST .../tool_results`.
> 
> Pending calls from `ActiveStateChangeEvent` are read with **`tool_name` / `args`** (replacing `name` / `arguments`). Outbound payloads use **`kind`** plus a nested **`tool_req`** (`tool_name`, `args`, `id`) instead of `type`, `tool_call_id`, and `is_error`. Successful runs post **`tool_result`** with `result`; failures post **`error_event`** with `error`, `origin: custom_tools`, and the same `tool_req`. Shared shaping lives in **`_tool_result_payload`**, used by sync and async executors. Tests in **`test_tools.py`** were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e245a9a7ffe41f6a5476f397061b328a8991c341. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->