### PR TITLE
Drop dead H_API_KEY mention from README credential note

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ that teaches the model how to drive the server.
 `~/.config/hai/.env`. `hai whoami` shows the resolved endpoint and whether you are
 authenticated; `hai logout` removes the stored key.
 
-Credentials resolve from flags, then `HAI_API_KEY`/`H_API_KEY` in the environment,
+Credentials resolve from flags, then `HAI_API_KEY` in the environment,
 then a local `.env`, then `~/.config/hai/.env`. Use `--base-url` or `HAI_API_BASE_URL`
 to target a specific Agent Platform host.
 


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Updates the **Credentials** paragraph so environment resolution is documented as flags, then **`HAI_API_KEY`**, then local `.env`, then `~/.config/hai/.env`—removing the legacy **`H_API_KEY`** alias that is no longer mentioned elsewhere in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15469496ab385ff8a15e31523c67a3d6506a0086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->