### PR TITLE
chore(sdk): sync to agent_platform@92963b2 (v0.1.11)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "0.1.10"
+version = "0.1.11"
 description = "Python SDK for H Company's Agent API: autonomous agents powered by Holo."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/hai_agents/core/client_wrapper.py
+++ b/src/hai_agents/core/client_wrapper.py
@@ -26,7 +26,16 @@ class BaseClientWrapper:
         self._logging = logging
 
     def get_headers(self) -> typing.Dict[str, str]:
+        import platform
+
         headers: typing.Dict[str, str] = {
+            "User-Agent": "hai_agents/0.1.11",
+            "X-HCompany-Client-Name": "hai_agents",
+            "X-HCompany-Client-Version": "0.1.11",
+            "X-HCompany-Client-Type": "sdk",
+            "X-HCompany-Language": "Python",
+            "X-HCompany-Runtime": f"python/{platform.python_version()}",
+            "X-HCompany-Platform": f"{platform.system().lower()}/{platform.release()}",
             **(self.get_custom_headers() or {}),
         }
         headers["Authorization"] = f"Bearer {self._get_api_key()}"

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "hai-agents"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `0.1.11` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@92963b2


<!-- CURSOR_SUMMARY -->
---

<!-- /CURSOR_SUMMARY -->
