### PR TITLE
Remove marketing tagline from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  Python SDK for <a href="https://hcompany.ai">H Company</a>'s <a href="https://hub.hcompany.ai/agent-api">Computer-Use Agents</a>. Launch autonomous agents powered by Holo, watch them work, and steer them mid-run.
+  Python SDK for <a href="https://hcompany.ai">H Company</a>'s <a href="https://hub.hcompany.ai/agent-api">Computer-Use Agents</a>.
 </p>
 
 <p align="center">


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no code or API impact.
> 
> **Overview**
> Shortens the README hero line so it only states that the package is the **Python SDK** for H Company’s **Computer-Use Agents**, and drops the extra sentence about launching Holo-powered agents, watching them work, and steering mid-run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52240831b4bbd683830d6eb635434ab2d01fc567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->