### PR TITLE
Fix `hai run` 422 by omitting empty overrides

### DIFF
--- a/src/hai_agents_cli/app.py
+++ b/src/hai_agents_cli/app.py
@@ -170,13 +170,14 @@ def run(
     state = _state(ctx)
     client = _client(state)
     overrides = _parse_overrides(override or [])
-    params = {
+    params: dict[str, Any] = {
         "agent": agent,
         "messages": task,
         "max_steps": max_steps,
         "max_time_s": max_time_s,
-        "overrides": overrides or None,
     }
+    if overrides:
+        params["overrides"] = overrides
     try:
         assert_request_under_limit(params)
         session = client.sessions.create_session(**params)


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI request-shape change with no auth or data handling impact; behavior with `-o` is unchanged.
> 
> **Overview**
> Fixes **`hai run`** returning **422** when no `-o` / `--override` flags are used.
> 
> Session create params no longer include **`overrides`** when `_parse_overrides` yields an empty dict. Previously the CLI always sent **`overrides: null`** (from `overrides or None`), which the API rejected; the field is now omitted unless at least one override is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 930867fed2b556b425b05f33c1aa0b2689f45603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->