### PR TITLE
Gracefully gate `hai` CLI behind [cli] extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ all = [
 ]
 
 [project.scripts]
-hai = "hai_agents_cli.app:main"
+hai = "hai_agents_cli:main"
 
 [project.urls]
 Homepage = "https://hcompany.ai"

--- a/src/hai_agents_cli/__init__.py
+++ b/src/hai_agents_cli/__init__.py
@@ -1,1 +1,18 @@
 """Command-line interface for the H Agent API SDK."""
+
+_CLI_EXTRAS = {"typer", "rich", "dotenv"}
+_CLI_HINT = "The `hai` CLI needs extra dependencies. Install them with: pip install 'hai-agents[cli]'"
+
+
+def main() -> None:
+    """Console-script entry point; fails clearly when the CLI extras are not installed."""
+    try:
+        from .app import main as _run
+    except ModuleNotFoundError as exc:
+        if (exc.name or "").split(".")[0] not in _CLI_EXTRAS:
+            raise
+        import sys
+
+        print(_CLI_HINT, file=sys.stderr)
+        raise SystemExit(1) from None
+    _run()

--- a/src/hai_agents_cli/__main__.py
+++ b/src/hai_agents_cli/__main__.py
@@ -1,6 +1,6 @@
 """Run the H Agent API CLI with `python -m hai_agents_cli`."""
 
-from .app import main
+from . import main
 
 if __name__ == "__main__":
     main()

--- a/tests/test_cli_drift.py
+++ b/tests/test_cli_drift.py
@@ -49,7 +49,7 @@ def test_project_exposes_cli_extras() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())
 
     assert set(pyproject["project"]["optional-dependencies"]) >= {"cli", "all"}
-    assert pyproject["project"]["scripts"]["hai"] == "hai_agents_cli.app:main"
+    assert pyproject["project"]["scripts"]["hai"] == "hai_agents_cli:main"
     assert "hai-mcp" not in pyproject["project"]["scripts"]
 
 


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Entry-point and import-order changes only; no auth, API, or data-handling behavior is modified.
> 
> **Overview**
> The **`hai` console script** now points at **`hai_agents_cli:main`** instead of importing **`app`** directly, so users who install the base package without **`[cli]`** get a clear error instead of an obscure import failure.
> 
> **`main()`** in **`hai_agents_cli/__init__.py`** lazily imports **`app.main`** and, on **`ModuleNotFoundError`** for **`typer`**, **`rich`**, or **`dotenv`**, prints install instructions (`pip install 'hai-agents[cli]'`) to stderr and exits with code 1. **`python -m hai_agents_cli`** goes through the same gated entry point. A drift test asserts the updated **`pyproject.toml`** script target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1b5b8c5375c6bc787100ce955b25b2ff937c4cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->