### PR TITLE
Harden the hai CLI and add release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to `hai-agents` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.12]
+
+Baseline public release of the Computer-Use Agents SDK and `hai` CLI. Earlier
+`0.1.x` releases are available on [PyPI](https://pypi.org/project/hai-agents/#history).
+
+[Unreleased]: https://github.com/hcompai/hai-agents-python/compare/v0.1.12...HEAD
+[0.1.12]: https://github.com/hcompai/hai-agents-python/releases/tag/v0.1.12

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ result = client.run_session(
     messages="What are the top 3 stories on Hacker News right now?",
 )
 
-print(result.status)  # "completed"
+print(result.status)  # a settled state: "idle" on EU (the default), "completed" on US
 print(result.answer)
 ```
 

--- a/src/hai_agents_cli/app.py
+++ b/src/hai_agents_cli/app.py
@@ -108,7 +108,7 @@ def whoami(ctx: typer.Context) -> None:
     data = {
         "base_url": credentials.resolve_base_url(state.base_url),
         "authenticated": authenticated,
-        "source": credentials.source(),
+        "source": credentials.source(state.api_key),
     }
     if state.json_output:
         _print_json(data)
@@ -242,6 +242,13 @@ def cancel(
         typer.confirm(f"Cancel session {session_id}?", abort=True)
     client = _client(state)
     try:
+        current = client.sessions.get_session_status(session_id)
+        if is_settled_session_status(current.status):
+            if state.json_output:
+                _print_json({"ack": False, "action": "cancel", "status": _status_text(current.status)})
+            else:
+                console.print(f"Session already {_status_text(current.status)}; nothing to cancel.")
+            return
         client.sessions.cancel_session(session_id)
     except Exception as exc:
         _raise_cli_error(exc)
@@ -278,6 +285,18 @@ def share(ctx: typer.Context, session_id: str = typer.Argument(...)) -> None:
         _print_json({"share_url": share_url})
     else:
         print(share_url)
+
+
+@sessions_app.command("unshare")
+def unshare(ctx: typer.Context, session_id: str = typer.Argument(...)) -> None:
+    """Revoke a session's public share URL."""
+    state = _state(ctx)
+    client = _client(state)
+    try:
+        client.sessions.unshare_session(session_id)
+    except Exception as exc:
+        _raise_cli_error(exc)
+    _print_ack("unshared", state.json_output)
 
 
 @sessions_app.command("status")
@@ -345,16 +364,24 @@ def watch(
             _raise_cli_error(TimeoutError(f"Session {session_id} did not settle within {timeout}s."))
         try:
             changes = client.sessions.get_session_changes(
-                session_id, from_index=from_index, include_events=True, wait_for_seconds=min(20, int(remaining))
+                session_id,
+                from_index=from_index,
+                include_events=True,
+                wait_for_seconds=max(1, min(20, int(remaining))),
             )
             for event in (changes.new_events if changes else None) or []:
-                if state.json_output:
-                    print(json.dumps(to_jsonable(event), sort_keys=True))
-                else:
-                    console.print(_event_line(from_index, event))
+                _emit_watch_event(state, from_index, event)
                 from_index += 1
             current = client.sessions.get_session_status(session_id)
             if is_settled_session_status(current.status):
+                # /changes is a delta endpoint: drain events that landed between the last poll
+                # and settling, otherwise the tail of the trajectory is silently dropped.
+                tail = client.sessions.get_session_changes(
+                    session_id, from_index=from_index, include_events=True, wait_for_seconds=0
+                )
+                for event in (tail.new_events if tail else None) or []:
+                    _emit_watch_event(state, from_index, event)
+                    from_index += 1
                 # The terminal answer lives on /changes, not /status.
                 final = client.sessions.get_session_changes(
                     session_id, from_index=0, include_events=False, wait_for_seconds=0
@@ -610,10 +637,38 @@ def _event_line(index: int, event) -> str:
     return f"[dim]{index:>4}[/dim] [cyan]{event_type}[/cyan]" + (f"  {detail}" if detail else "")
 
 
+def _emit_watch_event(state: AppState, index: int, event) -> None:
+    if state.json_output:
+        print(json.dumps(to_jsonable(event), sort_keys=True))
+    else:
+        console.print(_event_line(index, event))
+
+
+def _format_api_body(body) -> str:
+    """Human-readable message from an API error body, flattening 422 validation detail."""
+    if isinstance(body, str):
+        return body
+    detail = getattr(body, "detail", None)
+    if detail is None and isinstance(body, dict):
+        detail = body.get("detail")
+    if isinstance(detail, str):
+        return detail
+    if isinstance(detail, list):
+        parts = []
+        for item in detail:
+            loc = getattr(item, "loc", None) if not isinstance(item, dict) else item.get("loc")
+            msg = getattr(item, "msg", None) if not isinstance(item, dict) else item.get("msg")
+            if msg:
+                where = ".".join(str(p) for p in loc) if loc else ""
+                parts.append(f"{where}: {msg}" if where else str(msg))
+        if parts:
+            return "; ".join(parts)
+    return json.dumps(to_jsonable(body), sort_keys=True)
+
+
 def _raise_cli_error(exc: Exception) -> NoReturn:
     if isinstance(exc, ApiError):
-        body = exc.body
-        message = body if isinstance(body, str) else json.dumps(to_jsonable(body), sort_keys=True)
+        message = _format_api_body(exc.body)
         if exc.status_code is not None:
             message = f"API error {exc.status_code}: {message}"
     else:

--- a/src/hai_agents_cli/mcp_hosts.py
+++ b/src/hai_agents_cli/mcp_hosts.py
@@ -189,7 +189,7 @@ def wire_mcp(c: Client, url: str, key: str) -> tuple[Status, str]:
     if c.cli_cmd is not None:
         add = [_render(arg, url, key) for arg in c.cli_cmd]
         removes = [list(rm) for rm in c.cli_remove_cmds]
-        return _install_via_cli(add, removes)
+        return _install_via_cli(add, removes, secret=key)
     assert c.config_path is not None and c.key_path is not None and c.leaf is not None
     return _wire_json(Path(c.config_path).expanduser(), c.key_path, _render(c.leaf, url, key))
 
@@ -205,7 +205,9 @@ def _render(obj: Any, url: str, key: str) -> Any:
     return obj
 
 
-def _install_via_cli(add_cmd: list[str], remove_cmds: list[list[str]] | None = None) -> tuple[Status, str]:
+def _install_via_cli(
+    add_cmd: list[str], remove_cmds: list[list[str]] | None = None, secret: str | None = None
+) -> tuple[Status, str]:
     exe = shutil.which(add_cmd[0])
     if exe is None:
         return Status.ABSENT, f"{add_cmd[0]!r} not on PATH"
@@ -216,7 +218,11 @@ def _install_via_cli(add_cmd: list[str], remove_cmds: list[list[str]] | None = N
     try:
         subprocess.run([exe, *add_cmd[1:]], check=True, capture_output=True, text=True)
     except subprocess.CalledProcessError as exc:
-        return Status.FAILED, (exc.stderr or exc.stdout or str(exc)).strip()
+        # The CLI tends to echo the failing invocation (incl. the bearer header) back on stderr.
+        detail = (exc.stderr or exc.stdout or str(exc)).strip()
+        if secret:
+            detail = detail.replace(secret, "***")
+        return Status.FAILED, detail
     return Status.INSTALLED, f"via {add_cmd[0]} CLI"
 
 

--- a/src/hai_agents_common/credentials.py
+++ b/src/hai_agents_common/credentials.py
@@ -86,8 +86,10 @@ def clear_api_key() -> Path | None:
     return GLOBAL_ENV_PATH
 
 
-def source() -> str | None:
-    """Where the resolved credential comes from (`environment` or a file path), for `hai whoami`."""
+def source(explicit: ApiKey | None = None) -> str | None:
+    """Where the resolved credential comes from (`argument`, `environment`, or a file path), for `hai whoami`."""
+    if explicit:
+        return "argument"
     if os.environ.get(API_KEY_VAR):
         return "environment"
     for path in _env_paths():


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CLI UX, docs, and defensive polling/error handling; no auth or core SDK contract changes beyond exposing unshare in the CLI.
> 
> **Overview**
> Adds a **Keep a Changelog**-style `CHANGELOG.md` (baseline **0.1.12**) and clarifies in the README that `run_session` settled status is region-dependent (`idle` on EU, `completed` on US).
> 
> **CLI behavior fixes:** `hai whoami` reports key source as `argument` when `--api-key` is passed; `hai sessions cancel` is a no-op with a clear message (and JSON ack) if the session is already settled; `hai sessions watch` drains a final `/changes` poll so events between the last long-poll and settlement are not dropped, and uses at least 1s wait on polls; API errors flatten 422 validation `detail` for readable messages.
> 
> **New command:** `hai sessions unshare` revokes a session’s public share URL via the existing SDK `unshare_session`.
> 
> **MCP install:** CLI install failures redact the API key from echoed stderr/stdout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5974d18c06ac83bda4c0944bf2ec7d56186453a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->