### PR TITLE
docs: use canonical /computer-use-agents links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 </p>
 
 <p align="center">
-  Python SDK for <a href="https://hcompany.ai">H Company</a>'s <a href="https://hub.hcompany.ai/agent-api">Computer-Use Agents</a>.
+  Python SDK for <a href="https://hcompany.ai">H Company</a>'s <a href="https://hub.hcompany.ai/computer-use-agents">Computer-Use Agents</a>.
 </p>
 
 <p align="center">
-  <b><a href="https://hub.hcompany.ai/agent-api">Documentation</a></b>
+  <b><a href="https://hub.hcompany.ai/computer-use-agents">Documentation</a></b>
   &nbsp;·&nbsp;
   <a href="https://portal.hcompany.ai">Get an API key</a>
   &nbsp;·&nbsp;
@@ -182,7 +182,7 @@ A tool that raises is reported to the agent as a tool error rather than crashing
 
 ## Browser profiles and vaults
 
-Start a session on a browser that already knows the user. A [browser profile](https://hub.hcompany.ai/agent-api) restores saved cookies and storage from an earlier session, and a [vault](https://hub.hcompany.ai/agent-api) lets the agent sign in to sites with secrets that never enter its context. Bind both through per-run overrides:
+Start a session on a browser that already knows the user. A [browser profile](https://hub.hcompany.ai/computer-use-agents/browser-profiles) restores saved cookies and storage from an earlier session, and a [vault](https://hub.hcompany.ai/computer-use-agents/vaults) lets the agent sign in to sites with secrets that never enter its context. Bind both through per-run overrides:
 
 ```python
 result = client.run_session(
@@ -275,7 +275,7 @@ Credentials resolve from `--api-key`, then `HAI_API_KEY`, then a local `.env`. R
 
 ## Documentation
 
-Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/agent-api](https://hub.hcompany.ai/agent-api)**.
+Guides, core concepts, and the full API reference live at **[hub.hcompany.ai/computer-use-agents](https://hub.hcompany.ai/computer-use-agents)**.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ hai = "hai_agents_cli:main"
 Homepage = "https://hcompany.ai"
 Repository = "https://github.com/hcompai/hai-agents-python"
 Issues = "https://github.com/hcompai/hai-agents-python/issues"
-Documentation = "https://hub.hcompany.ai/agent-api"
+Documentation = "https://hub.hcompany.ai/computer-use-agents"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/hai_agents", "src/hai_agents_cli", "src/hai_agents_common"]

--- a/src/hai_agents_cli/host_skills/hai-agents/SKILL.md
+++ b/src/hai_agents_cli/host_skills/hai-agents/SKILL.md
@@ -42,4 +42,4 @@ User: *"is the H Company Agent API quickstart still showing the curl example"*
 
     run_agent
       agent: h/web-surfer-holo3-1-35b
-      task: Open https://hub.hcompany.ai/agent-api and confirm whether the quickstart page still shows a curl example. Return yes or no and quote the first line of the example if present.
+      task: Open https://hub.hcompany.ai/computer-use-agents/quickstart and confirm whether the quickstart page still shows a curl example. Return yes or no and quote the first line of the example if present.


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Link-only documentation and metadata changes with no runtime or API behavior impact.
> 
> **Overview**
> Replaces **hub.hcompany.ai/agent-api** documentation URLs with the canonical **hub.hcompany.ai/computer-use-agents** paths across user-facing docs and metadata.
> 
> **README** header, documentation CTA, browser profile/vault deep links, and the documentation section now point at `/computer-use-agents` and its `/browser-profiles` and `/vaults` subpaths. **pyproject.toml** `Documentation` project URL is updated to match. The **hai-agents** host skill example task now opens `/computer-use-agents/quickstart` instead of the old agent-api URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a96ff0f424409024e39799227d8ac14d067698d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->