### PR TITLE
chore(sdk): sync to agent_platform@87d8c14 (v1.0.2)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1306,7 +1306,7 @@
           "Skills"
         ],
         "summary": "List Skills",
-        "description": "List reserved + caller's org skills, optionally filtered by name or text search.",
+        "description": "List reserved + caller's org skills. Unauthenticated callers see reserved ``h/`` skills only.",
         "operationId": "list_skills_api_v2_skills_get",
         "security": [
           {
@@ -1682,7 +1682,7 @@
           "Environments"
         ],
         "summary": "List Environments",
-        "description": "List reserved + caller's org environments.",
+        "description": "List reserved + caller's org environments. Unauthenticated callers see reserved ``h/`` environments only.",
         "operationId": "list_environments_api_v2_environments_get",
         "security": [
           {
@@ -2076,7 +2076,7 @@
           "Agents"
         ],
         "summary": "List Agents",
-        "description": "List reserved + caller's org agents.",
+        "description": "List reserved + caller's org agents. Unauthenticated callers see reserved ``h/`` agents only.",
         "operationId": "list_agents_api_v2_agents_get",
         "security": [
           {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "1.0.1"
+version = "1.0.2"
 description = "Python SDK for H Company's Computer-Use Agents: autonomous agents powered by Holo."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/hai_agents/agents/client.py
+++ b/src/hai_agents/agents/client.py
@@ -46,7 +46,7 @@ class AgentsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> PageAgent:
         """
-        List reserved + caller's org agents.
+        List reserved + caller's org agents. Unauthenticated callers see reserved ``h/`` agents only.
 
         Parameters
         ----------
@@ -419,7 +419,7 @@ class AsyncAgentsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> PageAgent:
         """
-        List reserved + caller's org agents.
+        List reserved + caller's org agents. Unauthenticated callers see reserved ``h/`` agents only.
 
         Parameters
         ----------

--- a/src/hai_agents/agents/raw_client.py
+++ b/src/hai_agents/agents/raw_client.py
@@ -44,7 +44,7 @@ class RawAgentsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[PageAgent]:
         """
-        List reserved + caller's org agents.
+        List reserved + caller's org agents. Unauthenticated callers see reserved ``h/`` agents only.
 
         Parameters
         ----------
@@ -574,7 +574,7 @@ class AsyncRawAgentsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[PageAgent]:
         """
-        List reserved + caller's org agents.
+        List reserved + caller's org agents. Unauthenticated callers see reserved ``h/`` agents only.
 
         Parameters
         ----------

--- a/src/hai_agents/core/client_wrapper.py
+++ b/src/hai_agents/core/client_wrapper.py
@@ -29,9 +29,9 @@ class BaseClientWrapper:
         import platform
 
         headers: typing.Dict[str, str] = {
-            "User-Agent": "hai_agents/1.0.1",
+            "User-Agent": "hai_agents/1.0.2",
             "X-HCompany-Client-Name": "hai_agents",
-            "X-HCompany-Client-Version": "1.0.1",
+            "X-HCompany-Client-Version": "1.0.2",
             "X-HCompany-Client-Type": "sdk",
             "X-HCompany-Language": "Python",
             "X-HCompany-Runtime": f"python/{platform.python_version()}",

--- a/src/hai_agents/environments/client.py
+++ b/src/hai_agents/environments/client.py
@@ -46,7 +46,7 @@ class EnvironmentsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> EnvironmentPage:
         """
-        List reserved + caller's org environments.
+        List reserved + caller's org environments. Unauthenticated callers see reserved ``h/`` environments only.
 
         Parameters
         ----------
@@ -400,7 +400,7 @@ class AsyncEnvironmentsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> EnvironmentPage:
         """
-        List reserved + caller's org environments.
+        List reserved + caller's org environments. Unauthenticated callers see reserved ``h/`` environments only.
 
         Parameters
         ----------

--- a/src/hai_agents/environments/raw_client.py
+++ b/src/hai_agents/environments/raw_client.py
@@ -44,7 +44,7 @@ class RawEnvironmentsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[EnvironmentPage]:
         """
-        List reserved + caller's org environments.
+        List reserved + caller's org environments. Unauthenticated callers see reserved ``h/`` environments only.
 
         Parameters
         ----------
@@ -543,7 +543,7 @@ class AsyncRawEnvironmentsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[EnvironmentPage]:
         """
-        List reserved + caller's org environments.
+        List reserved + caller's org environments. Unauthenticated callers see reserved ``h/`` environments only.
 
         Parameters
         ----------

--- a/src/hai_agents/skills/client.py
+++ b/src/hai_agents/skills/client.py
@@ -39,7 +39,7 @@ class SkillsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> PageSkill:
         """
-        List reserved + caller's org skills, optionally filtered by name or text search.
+        List reserved + caller's org skills. Unauthenticated callers see reserved ``h/`` skills only.
 
         Parameters
         ----------
@@ -347,7 +347,7 @@ class AsyncSkillsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> PageSkill:
         """
-        List reserved + caller's org skills, optionally filtered by name or text search.
+        List reserved + caller's org skills. Unauthenticated callers see reserved ``h/`` skills only.
 
         Parameters
         ----------

--- a/src/hai_agents/skills/raw_client.py
+++ b/src/hai_agents/skills/raw_client.py
@@ -36,7 +36,7 @@ class RawSkillsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[PageSkill]:
         """
-        List reserved + caller's org skills, optionally filtered by name or text search.
+        List reserved + caller's org skills. Unauthenticated callers see reserved ``h/`` skills only.
 
         Parameters
         ----------
@@ -464,7 +464,7 @@ class AsyncRawSkillsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[PageSkill]:
         """
-        List reserved + caller's org skills, optionally filtered by name or text search.
+        List reserved + caller's org skills. Unauthenticated callers see reserved ``h/`` skills only.
 
         Parameters
         ----------

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "hai-agents"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Auto-generated from `agent_platform`'s codegen home (`sdk-codegen/`).

**Version:** `1.0.2` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@87d8c14


<!-- CURSOR_SUMMARY -->
---

<!-- /CURSOR_SUMMARY -->
