### PR TITLE
Fix out-of-sync SDK content (key URL, browser env shape, agent ids)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <p align="center">
   <b><a href="https://hub.hcompany.ai/computer-use-agents">Documentation</a></b>
   &nbsp;·&nbsp;
-  <a href="https://portal.hcompany.ai">Get an API key</a>
+  <a href="https://platform.hcompany.ai/settings/api-keys">Get an API key</a>
   &nbsp;·&nbsp;
   <a href="https://pypi.org/project/hai-agents/">PyPI</a>
   &nbsp;·&nbsp;
@@ -39,7 +39,7 @@ Add the optional command-line tools with the `cli` extra:
 pip install "hai-agents[cli]"
 ```
 
-Python 3.10 or newer is required. Get an API key at [portal.hcompany.ai](https://portal.hcompany.ai) and export it:
+Python 3.10 or newer is required. Get an API key at [platform.hcompany.ai/settings/api-keys](https://platform.hcompany.ai/settings/api-keys) and export it:
 
 ```bash
 export HAI_API_KEY=hk-...
@@ -271,7 +271,7 @@ hai sessions watch <session-id>
 hai mcp install           # add the hai-agents MCP server to Cursor, VS Code, Claude Code, ...
 ```
 
-Credentials resolve from `--api-key`, then `HAI_API_KEY`, then a local `.env`. Run `hai --help` for the full command set.
+Credentials resolve from `--api-key`, then `HAI_API_KEY`, then a local `.env`, then `~/.config/hai/.env`. Run `hai --help` for the full command set.
 
 ## Documentation
 

--- a/tests/integration/test_session_browser.py
+++ b/tests/integration/test_session_browser.py
@@ -2,7 +2,7 @@
 
 The agent is dropped on a search-engine start URL (set on the environment spec)
 and asked for Paris weather without being told which engine to use. Exercises
-local_browser provisioning, the agent using whatever page it lands on, and
+web browser provisioning, the agent using whatever page it lands on, and
 end-to-end answer extraction.
 
 Bing is used because it can be read without a CAPTCHA. The engine lives in the
@@ -40,8 +40,7 @@ def _poll_until_terminal(client: Client, session_id: str, timeout_s: float = 420
             return s
         if time.time() - start > timeout_s:
             pytest.fail(
-                f"session {session_id} did not finish in {timeout_s}s "
-                f"(last status: {s.status}, steps: {s.steps})"
+                f"session {session_id} did not finish in {timeout_s}s (last status: {s.status}, steps: {s.steps})"
             )
         time.sleep(3)
 
@@ -62,9 +61,8 @@ def test_browser_session_finds_paris_weather(client: Client, run_id: str, create
             "environments": [
                 {
                     "id": "browser",
-                    "kind": "local_browser",
-                    "width": 1280,
-                    "height": 800,
+                    "kind": "web",
+                    "mode": {"type": "visual", "width": 1280, "height": 800},
                     "start_url": SEARCH_ENGINE_START_URL,
                 }
             ],

--- a/tests/test_answer_schema.py
+++ b/tests/test_answer_schema.py
@@ -71,7 +71,7 @@ class TestSchemaInjection:
         assert "JobListing" in schema["$defs"]
 
     def test_catalog_agent_injected_via_overrides(self) -> None:
-        params: dict = {"agent": "h/web-surfer"}
+        params: dict = {"agent": "h/web-surfer-pro"}
         _attach_answer_schema(params, JobListings)
         assert params["overrides"]["agent.answer_format"]["title"] == "JobListings"
 
@@ -79,7 +79,7 @@ class TestSchemaInjection:
         with pytest.raises(ValueError, match="conflicts"):
             _attach_answer_schema({"agent": {"answer_format": {"type": "object"}}}, JobListings)
         with pytest.raises(ValueError, match="conflicts"):
-            _attach_answer_schema({"agent": "h/web-surfer", "overrides": {"agent.answer_format": {}}}, JobListings)
+            _attach_answer_schema({"agent": "h/web-surfer-pro", "overrides": {"agent.answer_format": {}}}, JobListings)
 
     def test_inline_agent_with_answer_format_override_conflicts(self) -> None:
         with pytest.raises(ValueError, match="conflicts"):
@@ -87,10 +87,10 @@ class TestSchemaInjection:
 
     def test_non_model_schema_rejected(self) -> None:
         with pytest.raises(TypeError, match="BaseModel"):
-            _attach_answer_schema({"agent": "h/web-surfer"}, dict)
+            _attach_answer_schema({"agent": "h/web-surfer-pro"}, dict)
 
     def test_user_overrides_preserved(self) -> None:
-        params: dict = {"agent": "h/web-surfer", "overrides": {"agent.max_steps": 5}}
+        params: dict = {"agent": "h/web-surfer-pro", "overrides": {"agent.max_steps": 5}}
         _attach_answer_schema(params, JobListings)
         assert params["overrides"]["agent.max_steps"] == 5
 
@@ -98,7 +98,7 @@ class TestSchemaInjection:
 class TestAnswerParseBack:
     def test_completed_answer_validates_into_model(self) -> None:
         client = _Client(_VALID_ANSWER)
-        result = run_session(client, agent="h/web-surfer", messages="find jobs", answer_schema=JobListings)  # type: ignore[arg-type]
+        result = run_session(client, agent="h/web-surfer-pro", messages="find jobs", answer_schema=JobListings)  # type: ignore[arg-type]
         assert isinstance(result.answer, JobListings)
         assert result.answer.jobs[1].title == "SWE"
         assert client.sessions.created_with["overrides"]["agent.answer_format"]["title"] == "JobListings"
@@ -152,7 +152,7 @@ class TestComposesWithTools:
 
         client = _Client(_VALID_ANSWER)
         result = run_session(  # type: ignore[arg-type]
-            client, agent="h/web-surfer", messages="go", answer_schema=JobListings, tools=[get_weather]
+            client, agent="h/web-surfer-pro", messages="go", answer_schema=JobListings, tools=[get_weather]
         )
         overrides = client.sessions.created_with["overrides"]
         assert overrides["agent.answer_format"]["title"] == "JobListings"


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only updates with no changes to SDK runtime logic in this diff.
> 
> **Overview**
> Aligns user-facing docs and tests with the current platform and API shapes.
> 
> **README** now points “Get an API key” and setup instructions at `platform.hcompany.ai/settings/api-keys` instead of `portal.hcompany.ai`, and documents that the `hai` CLI also loads credentials from `~/.config/hai/.env` (after `--api-key`, `HAI_API_KEY`, and a local `.env`).
> 
> The slow browser integration test provisions the environment as `kind: "web"` with `mode: {"type": "visual", "width": ..., "height": ...}` instead of `local_browser` with top-level width/height, and the docstring refers to web browser provisioning.
> 
> **`tests/test_answer_schema.py`** uses catalog agent id `h/web-surfer-pro` everywhere tests previously referenced `h/web-surfer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e98f4a314fc9cf4dd72fb11d0779d5066e1b3b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->