### PR TITLE
Mirror agent_artifact in CreateSessionParams

### DIFF
--- a/src/hai_agents/polling.py
+++ b/src/hai_agents/polling.py
@@ -45,6 +45,7 @@ class CreateSessionParams(typing_extensions.TypedDict, total=False):
     """Typed ``create_session`` kwargs; mirror new ``SessionRequest`` fields here to keep autocomplete."""
 
     agent: typing_extensions.Required[SessionRequestAgent]
+    agent_artifact: typing.Optional[str]
     idempotency_key: typing.Optional[str]
     messages: typing.Optional[SessionRequestMessages]
     overrides: typing.Optional[typing.Dict[str, typing.Any]]


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing-only mirror of an existing API field; no runtime logic changes.
> 
> **Overview**
> Adds **`agent_artifact`** to the `CreateSessionParams` TypedDict so it matches `SessionRequest` and the generated `create_session` API.
> 
> Callers can pass **`agent_artifact`** into **`run_session`** / **`async_run_session`** with correct typing and IDE autocomplete; kwargs still flow through to **`create_session`** unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1f0fd19cd030e3f711c1d0ce7e49306cab58288. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->