### PR TITLE
Add outcome/error/error_code to test status fakes

### DIFF
--- a/tests/test_answer_schema.py
+++ b/tests/test_answer_schema.py
@@ -32,6 +32,9 @@ _VALID_ANSWER = {"jobs": [{"title": "RE", "company": "H"}, {"title": "SWE", "com
 class _Status:
     def __init__(self, status: str) -> None:
         self.status = status
+        self.outcome: typing.Optional[str] = None
+        self.error: typing.Optional[str] = None
+        self.error_code: typing.Optional[str] = None
 
 
 class _Changes:

--- a/tests/test_settle.py
+++ b/tests/test_settle.py
@@ -16,7 +16,7 @@ class _Sessions:
         return SimpleNamespace(new_events=[], answer=self._answer)
 
     def get_session_status(self, id):
-        return SimpleNamespace(status=self._statuses.pop(0))
+        return SimpleNamespace(status=self._statuses.pop(0), outcome=None, error=None, error_code=None)
 
 
 def test_wait_stops_on_idle_and_returns_answer():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -87,7 +87,7 @@ class _FakeSessions:
 
     def get_session_status(self, id):
         changes, status = self._polls.pop(0)
-        return SimpleNamespace(status=status)
+        return SimpleNamespace(status=status, outcome=None, error=None, error_code=None)
 
 
 def _pending(id, tool_name, args=None):
@@ -255,7 +255,7 @@ def test_wait_joining_past_advertisement_recovers_pending():
             return None
 
         def get_session_status(self, id):
-            return SimpleNamespace(status=self._statuses.pop(0))
+            return SimpleNamespace(status=self._statuses.pop(0), outcome=None, error=None, error_code=None)
 
     httpx = _FakeHttpx()
     client = SimpleNamespace(sessions=_MidStreamSessions(), _client_wrapper=SimpleNamespace(httpx_client=httpx))


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture updates with no production code or behavior changes.
> 
> **Overview**
> Test doubles for `get_session_status` now expose **`outcome`**, **`error`**, and **`error_code`** alongside `status`, matching the shape production polling code expects from real session status responses.
> 
> In `test_answer_schema.py`, the `_Status` helper gains optional attributes defaulting to `None`. In `test_settle.py` and `test_tools.py`, `SimpleNamespace` status objects returned from fake sessions include the same three fields set to `None`. **No runtime library behavior changes**—only offline test fixtures are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cedcce3733df45f27366ad909fdd4380af004afa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->