### PR TITLE
docs: clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,18 @@ Launch the built-in `h/web-surfer-pro` agent, which ships with its own browser, 
 ```python
 from hai_agents import Client
 
-client = Client()  # reads HAI_API_KEY from the environment
+client = Client()
 
 result = client.run_session(
     agent="h/web-surfer-pro",
     messages="What are the top 3 stories on Hacker News right now?",
 )
 
-print(result.status)  # a settled state: "idle" on EU (the default), "completed" on US
+print(result.status)
 print(result.answer)
 ```
+
+`Client()` reads `HAI_API_KEY` from the environment.
 
 `result` is a `SessionRunResult`: `id`, `status`, `answer`, the accumulated `events`, and `final_changes`.
 
@@ -87,22 +89,24 @@ print(result.status, result.answer)
 A handle bound to the session `id` exposes the full lifecycle. Read the agent's progress at three levels of detail:
 
 ```python
-session.status()               # cheap snapshot: state, step count, token usage
-session.changes(from_index=0)  # new events and the final answer, long-polled
-session.get()                  # the full Session resource
+session.status()
+session.changes(from_index=0)
+session.get()
 ```
+
+`status()` is a cheap snapshot with the state, step count, and token usage. `changes(from_index=0)` long-polls for new events and the final answer. `get()` returns the full Session resource.
 
 While the session is not in a terminal state, you can intervene:
 
 ```python
 session.send_message({"type": "user_message", "message": "Only consider the last 24 hours"})
-session.pause()         # halt with state preserved
-session.resume()        # continue where it left off
-session.force_answer()  # stop exploring and answer from what it has
-session.cancel()        # stop for good; ends in "interrupted"
+session.pause()
+session.resume()
+session.force_answer()
+session.cancel()
 ```
 
-`send_message` redirects the agent on its next step. Sending a message to an `idle` session also wakes it.
+`send_message` redirects the agent on its next step and wakes an `idle` session. `pause` halts with state preserved until `resume`. `force_answer` makes the agent stop exploring and answer from what it has. `cancel` ends the session as `interrupted`.
 
 ## Multi-turn sessions
 
@@ -142,7 +146,7 @@ result = client.run_session(
     answer_schema=Jobs,
 )
 
-for job in result.answer.jobs:  # result.answer is a Jobs instance
+for job in result.answer.jobs:
     print(job.title, "@", job.company)
 ```
 
@@ -229,13 +233,17 @@ print(link.share_url)
 
 ## Regions and configuration
 
-The client targets the EU region by default. Point it at the US region or a custom URL, and override the API key in code when you do not want to use the environment variable:
+The client targets the EU region by default; pass `environment` to use the US region instead:
 
 ```python
 from hai_agents import Client, HaiAgentsEnvironment
 
 client = Client(environment=HaiAgentsEnvironment.US)
-# or
+```
+
+`Client` also accepts a custom `base_url`, and an `api_key` when you do not want to use the environment variable:
+
+```python
 client = Client(base_url="https://agp.hcompany.ai", api_key="hk-...")
 ```
 
@@ -264,14 +272,14 @@ print(event.type, event.data)
 The `cli` extra installs the `hai` command for driving agents from your terminal:
 
 ```bash
-hai login                 # browser sign-in, stores a key in ~/.config/hai/.env
+hai login
 hai run "What's the top story on Hacker News?"
 hai sessions list
 hai sessions watch <session-id>
-hai mcp install           # add the hai-agents MCP server to Cursor, VS Code, Claude Code, ...
+hai mcp install
 ```
 
-Credentials resolve from `--api-key`, then `HAI_API_KEY`, then a local `.env`, then `~/.config/hai/.env`. Run `hai --help` for the full command set.
+`hai login` signs in through the browser and stores a key in `~/.config/hai/.env`. `hai mcp install` adds the hai-agents MCP server to Cursor, VS Code, Claude Code, and other MCP clients. Credentials resolve from `--api-key`, then `HAI_API_KEY`, then a local `.env`, then `~/.config/hai/.env`. Run `hai --help` for the full command set.
 
 ## Documentation
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or API behavior changes.
> 
> **Overview**
> **README-only** polish: examples are stripped of inline comments, and the same explanations are moved into short prose after the snippets so the code blocks stay minimal.
> 
> **Quickstart** documents `HAI_API_KEY` in a follow-up sentence instead of a `Client()` comment. **Watch and steer** adds paragraphs for `status()` / `changes()` / `get()` and for `send_message`, `pause`, `resume`, `force_answer`, and `cancel`. **Regions and configuration** splits EU/US (`environment`) and custom `base_url` / `api_key` into separate examples with tighter intro copy. **Command line** drops bash inline comments and spells out what `hai login` and `hai mcp install` do in the section text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b49f4db49b0c11fdf105070a2d0bb3f4a0f5ebb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->