### PR TITLE
feat(tools): enable OTP retrieval via HITL or IMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,32 @@ def lookup(order_id: str) -> dict:
 
 A tool that raises is reported to the agent as a tool error rather than crashing the run. With `AsyncClient`, tools may be `async def`.
 
+### Prebuilt: one-time passwords (2FA)
+
+`hai_agents_tools` ships ready-made tools. `otp_tool` lets the agent ask for a one-time password, verification code, or confirmation link when a login or signup step needs one. Without a handler it prompts on stdin; `imap_otp_handler` reads the code straight from a mailbox over IMAP (for Gmail, use an app password).
+
+```python
+import os
+
+from hai_agents import Client
+from hai_agents_tools import imap_otp_handler, otp_tool
+
+handler = imap_otp_handler(
+    host="imap.gmail.com",
+    username="agent-inbox@gmail.com",
+    password=os.environ["GMAIL_APP_PASSWORD"],
+)
+
+client = Client()
+result = client.run_session(
+    agent="h/web-surfer-pro",
+    messages="Log in to example.com and check for new notifications",
+    tools=[otp_tool(handler)],
+)
+```
+
+Like every custom tool, the handler runs entirely in your process: the IMAP credentials never leave your machine, and the agent only receives the single extracted code or link -- never mailbox contents.
+
 ## Browser profiles and vaults
 
 Start a session on a browser that already knows the user. A [browser profile](https://hub.hcompany.ai/computer-use-agents/browser-profiles) restores saved cookies and storage from an earlier session, and a [vault](https://hub.hcompany.ai/computer-use-agents/vaults) lets the agent sign in to sites with secrets that never enter its context. Bind both through per-run overrides:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ Issues = "https://github.com/hcompai/hai-agents-python/issues"
 Documentation = "https://hub.hcompany.ai/computer-use-agents"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/hai_agents", "src/hai_agents_cli", "src/hai_agents_common", "src/hai_agents_local"]
+packages = ["src/hai_agents", "src/hai_agents_cli", "src/hai_agents_common", "src/hai_agents_local", "src/hai_agents_tools"]
 
 [dependency-groups]
 dev = [

--- a/src/hai_agents_tools/__init__.py
+++ b/src/hai_agents_tools/__init__.py
@@ -1,0 +1,29 @@
+"""Prebuilt custom tools for the hai-agents SDK.
+
+The generic plumbing (:class:`hai_agents.Tool`, :func:`hai_agents.tool`,
+:func:`hai_agents.as_tools`) ships with the generated ``hai_agents`` package. This
+package holds the prebuilt tools built on top of it, one module per
+tool (``otp``, ...), re-exported here.
+"""
+
+from .otp import (
+    OTP_TOOL_DESCRIPTION,
+    OTP_TOOL_INPUT_SCHEMA,
+    OTP_TOOL_NAME,
+    OtpHandler,
+    OtpRequest,
+    extract_otp,
+    imap_otp_handler,
+    otp_tool,
+)
+
+__all__ = [
+    "OTP_TOOL_DESCRIPTION",
+    "OTP_TOOL_INPUT_SCHEMA",
+    "OTP_TOOL_NAME",
+    "OtpHandler",
+    "OtpRequest",
+    "extract_otp",
+    "imap_otp_handler",
+    "otp_tool",
+]

--- a/src/hai_agents_tools/otp.py
+++ b/src/hai_agents_tools/otp.py
@@ -1,0 +1,269 @@
+"""Prebuilt OTP tool: hand the agent one-time passwords, verification codes, and confirmation links.
+
+The agent calls :func:`otp_tool` when a login or verification step asks for a code or
+link sent out of band; the handler resolves it -- interactively on stdin by default, or
+straight from a mailbox with :func:`imap_otp_handler`.
+"""
+
+from __future__ import annotations
+
+import html
+import inspect
+import re
+import time
+import typing
+from dataclasses import dataclass
+
+from hai_agents.tools import Tool
+
+# Public surface, re-exported by the tools package __init__ (enforced by the SDK tests).
+__all__ = [
+    "OTP_TOOL_DESCRIPTION",
+    "OTP_TOOL_INPUT_SCHEMA",
+    "OTP_TOOL_NAME",
+    "OtpHandler",
+    "OtpRequest",
+    "extract_otp",
+    "imap_otp_handler",
+    "otp_tool",
+]
+
+OTP_TOOL_NAME = "request_otp"
+
+OTP_TOOL_DESCRIPTION = (
+    "Ask the human operator for a one-time password (OTP), verification code, or "
+    "confirmation link. Use this whenever a login, signup, or verification step "
+    "asks for a code or link that was sent to the user out of band (email, SMS, "
+    "or an authenticator app). Never guess or fabricate a code: call this tool "
+    "and wait for the value."
+)
+
+OTP_TOOL_INPUT_SCHEMA: typing.Dict[str, typing.Any] = {
+    "type": "object",
+    "properties": {
+        "prompt": {
+            "type": "string",
+            "description": (
+                "Message shown to the user explaining exactly what is needed, "
+                "e.g. 'Enter the 6-digit code sent to j***@example.com'."
+            ),
+        },
+        "kind": {
+            "type": "string",
+            "enum": ["code", "link"],
+            "default": "code",
+            "description": "Whether a code (numeric or alphanumeric) or a full confirmation URL is expected.",
+        },
+        "source": {
+            "type": "string",
+            "description": "Where the code or link was sent, e.g. 'email', 'sms', 'authenticator app'.",
+        },
+    },
+    "required": ["prompt"],
+}
+
+
+@dataclass(frozen=True)
+class OtpRequest:
+    """One OTP request from the agent, passed to the :func:`otp_tool` handler."""
+
+    prompt: str
+    kind: str = "code"  # "code" or "link"
+    source: typing.Optional[str] = None
+
+
+OtpHandler = typing.Callable[[OtpRequest], typing.Union[str, typing.Awaitable[str]]]
+
+
+def _default_otp_handler(request: OtpRequest) -> str:
+    """Interactive fallback: prompt for the value on stdin."""
+    label = "link" if request.kind == "link" else "code"
+    message = request.prompt
+    if request.source:
+        message += f" (sent via {request.source})"
+    return input(f"{message}\nEnter the {label}: ")
+
+
+def _validated_otp(value: str, kind: str) -> str:
+    value = (value or "").strip()
+    if not value:
+        raise ValueError(f"No {'link' if kind == 'link' else 'code'} was provided.")
+    return value
+
+
+async def _await_validated_otp(value: typing.Awaitable[str], kind: str) -> str:
+    return _validated_otp(await value, kind)
+
+
+def otp_tool(
+    handler: typing.Optional[OtpHandler] = None,
+    *,
+    name: str = OTP_TOOL_NAME,
+    description: str = OTP_TOOL_DESCRIPTION,
+) -> Tool:
+    """A ready-made custom tool the agent calls when it needs an OTP, verification code, or confirmation link.
+
+    ``handler`` receives an :class:`OtpRequest` and returns the value the user supplied
+    (it may be async: fetch the code from an inbox API, a Slack prompt, ...). Without a
+    handler, the tool prompts interactively on stdin.
+
+    Usage::
+
+        handler = imap_otp_handler(
+            host="imap.gmail.com",
+            username="agent-inbox@gmail.com",
+            password=os.environ["GMAIL_APP_PASSWORD"],  # Google app password
+        )
+        client.run_session(agent="surfer", messages="Log in to example.com", tools=[otp_tool(handler)])
+    """
+    resolved = handler or _default_otp_handler
+
+    def run(prompt: str, kind: str = "code", source: typing.Optional[str] = None) -> typing.Any:
+        result = resolved(OtpRequest(prompt=prompt, kind=kind, source=source))
+        if inspect.isawaitable(result):
+            return _await_validated_otp(result, kind)
+        return _validated_otp(result, kind)
+
+    return Tool(name=name, description=description, input_schema=OTP_TOOL_INPUT_SCHEMA, fn=run)
+
+
+_OTP_URL = re.compile(r"https?://[^\s<>\"')\]]+")
+_OTP_LINK_HINT = re.compile(
+    r"verify|confirm|activat|validat|sign-?in|log-?in|magic|authenticat|authoriz"
+    r"|(?<![a-z])oauth|(?<![a-z])auth(?![a-z])|(?<![a-z])otp(?![a-z])|token",
+    re.IGNORECASE,
+)
+_OTP_KEYWORD = re.compile(r"(?:code|otp|passcode|password|pin|token)\b", re.IGNORECASE)
+_OTP_TOKEN = re.compile(r"\b\d{3,4}(?:[ -]\d{3,4}){1,2}\b|\b[A-Za-z0-9][A-Za-z0-9-]{2,10}[A-Za-z0-9]\b")
+_OTP_BARE_CODE = re.compile(r"\b\d{3,4}(?:[ -]\d{3,4}){1,2}\b|\b\d{4,8}\b")
+
+
+def extract_otp(
+    text: str,
+    kind: str = "code",
+    code_pattern: typing.Optional[typing.Pattern[str]] = None,
+) -> typing.Optional[str]:
+    """Best-effort extraction of an OTP code or confirmation link from an email's text.
+
+    Links: prefers a URL that looks like a verification/login link, falling back to the
+    first URL. Codes: prefers a digit-bearing token near a keyword ("code", "OTP",
+    "passcode", ...), falling back to any standalone digit run -- contiguous ("482913")
+    or grouped ("123 456", "1234-5678"). ``code_pattern`` replaces the code heuristics;
+    its first capture group (or the whole match) is the code.
+    """
+    if kind == "link":
+        urls = _OTP_URL.findall(text)
+        hinted = [u for u in urls if _OTP_LINK_HINT.search(u)]
+        candidates = hinted or urls
+        return candidates[0] if candidates else None
+    if code_pattern is not None:
+        match = code_pattern.search(text)
+        if match is None:
+            return None
+        return match.group(1) if match.groups() else match.group(0)
+    # HTML-derived text carries long whitespace runs (stripped tags, table layouts)
+    # that would push the code out of the keyword window; collapse them first.
+    text = re.sub(r"\s+", " ", text)
+    for keyword in _OTP_KEYWORD.finditer(text):
+        window = text[keyword.end() : keyword.end() + 60]
+        for token in _OTP_TOKEN.findall(window):
+            if any(ch.isdigit() for ch in token):
+                return token
+    match = _OTP_BARE_CODE.search(text)
+    return match.group(0) if match else None
+
+
+def _html_to_text(markup: str) -> str:
+    markup = re.sub(r"<(?:script|style)\b[^>]*>.*?</(?:script|style)>", " ", markup, flags=re.IGNORECASE | re.DOTALL)
+    # Surface link targets: html mail hides the URL behind anchor text ("Click here").
+    markup = re.sub(r"<a\b[^>]*?href=[\"']([^\"']+)[\"'][^>]*>", r" \1 ", markup, flags=re.IGNORECASE)
+    return html.unescape(re.sub(r"<[^>]+>", " ", markup))
+
+
+def _message_text(message: typing.Any) -> str:
+    parts = [str(message.get("Subject") or "")]
+    body = message.get_body(preferencelist=("plain", "html"))
+    if body is not None:
+        content = body.get_content()
+        parts.append(_html_to_text(content) if body.get_content_type() == "text/html" else content)
+    return "\n".join(parts)
+
+
+def imap_otp_handler(
+    *,
+    host: str,
+    username: str,
+    password: str,
+    port: int = 993,
+    mailbox: str = "INBOX",
+    sender: typing.Optional[str] = None,
+    timeout_s: float = 120.0,
+    poll_interval_s: float = 5.0,
+    max_age_s: float = 900.0,
+    mark_seen: bool = True,
+    code_pattern: typing.Union[str, typing.Pattern[str], None] = None,
+) -> OtpHandler:
+    """An :func:`otp_tool` handler that reads the OTP code or confirmation link from a mailbox over IMAP.
+
+    Polls ``mailbox`` for unread messages -- newest first, at most ``max_age_s`` old,
+    optionally filtered by ``sender`` -- and runs :func:`extract_otp` on each until one
+    yields a value; that message is then marked read (``mark_seen``) so a retry cannot
+    reuse a stale code. Raises :class:`TimeoutError` after ``timeout_s`` without a
+    match, which surfaces to the agent as a tool error. Works with any IMAP server
+    (for Gmail / Google Workspace use an app password).
+
+    Privacy: like every custom tool, this runs entirely in your process. The IMAP
+    credentials and connection stay on your machine and are never sent to the API or
+    the agent. The agent cannot browse or read the mailbox: it only calls the tool,
+    and the only thing sent back is the single extracted code or link -- never email
+    bodies, subjects, senders, or any other message content.
+
+    Usage::
+
+        handler = imap_otp_handler(
+            host="imap.gmail.com",
+            username="agent-inbox@gmail.com",
+            password=os.environ["GMAIL_APP_PASSWORD"],
+            sender="no-reply@service-being-logged-into.com",
+        )
+        client.run_session(agent="surfer", messages="Log in to example.com", tools=[otp_tool(handler)])
+    """
+    compiled = re.compile(code_pattern, re.IGNORECASE) if isinstance(code_pattern, str) else code_pattern
+
+    def handler(request: OtpRequest) -> str:
+        import email
+        import email.policy
+        import imaplib
+
+        deadline = time.monotonic() + timeout_s
+        conn = imaplib.IMAP4_SSL(host, port)
+        try:
+            conn.login(username, password)
+            while True:
+                conn.select(mailbox)
+                criteria = ["UNSEEN"] + (["FROM", f'"{sender}"'] if sender else [])
+                _, data = conn.search(None, *criteria)
+                for msg_id in reversed((data[0] or b"").split()):
+                    _, fetched = conn.fetch(msg_id, "(INTERNALDATE BODY.PEEK[])")
+                    if not fetched or not isinstance(fetched[0], tuple):
+                        continue
+                    received = imaplib.Internaldate2tuple(fetched[0][0])
+                    if received is not None and time.time() - time.mktime(received) > max_age_s:
+                        continue
+                    message = email.message_from_bytes(fetched[0][1], policy=email.policy.default)
+                    value = extract_otp(_message_text(message), request.kind, compiled)
+                    if value:
+                        if mark_seen:
+                            conn.store(msg_id, "+FLAGS", "\\Seen")
+                        return value
+                if time.monotonic() >= deadline:
+                    label = "link" if request.kind == "link" else "code"
+                    raise TimeoutError(f"No {label} found in unread mail for {username} within {timeout_s:.0f}s.")
+                time.sleep(poll_interval_s)
+        finally:
+            try:
+                conn.logout()
+            except Exception:
+                pass
+
+    return handler

--- a/src/hai_agents_tools/otp.py
+++ b/src/hai_agents_tools/otp.py
@@ -244,14 +244,19 @@ def imap_otp_handler(
                 criteria = ["UNSEEN"] + (["FROM", f'"{sender}"'] if sender else [])
                 _, data = conn.search(None, *criteria)
                 for msg_id in reversed((data[0] or b"").split()):
-                    _, fetched = conn.fetch(msg_id, "(INTERNALDATE BODY.PEEK[])")
-                    if not fetched or not isinstance(fetched[0], tuple):
+                    try:
+                        _, fetched = conn.fetch(msg_id, "(INTERNALDATE BODY.PEEK[])")
+                        if not fetched or not isinstance(fetched[0], tuple):
+                            continue
+                        received = imaplib.Internaldate2tuple(fetched[0][0])
+                        if received is not None and time.time() - time.mktime(received) > max_age_s:
+                            continue
+                        message = email.message_from_bytes(fetched[0][1], policy=email.policy.default)
+                        text = _message_text(message)
+                    except Exception:
+                        # One malformed or oversized message must not abort the poll; skip it.
                         continue
-                    received = imaplib.Internaldate2tuple(fetched[0][0])
-                    if received is not None and time.time() - time.mktime(received) > max_age_s:
-                        continue
-                    message = email.message_from_bytes(fetched[0][1], policy=email.policy.default)
-                    value = extract_otp(_message_text(message), request.kind, compiled)
+                    value = extract_otp(text, request.kind, compiled)
                     if value:
                         if mark_seen:
                             conn.store(msg_id, "+FLAGS", "\\Seen")

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -1,0 +1,225 @@
+"""Behavior tests for the prebuilt OTP tool (``hai_agents_tools.otp``).
+
+Package resolution and re-export meta checks live in test_tools_package; this file
+only tests the OTP tool's behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Awaitable
+
+import pytest
+
+from hai_agents_tools import OTP_TOOL_INPUT_SCHEMA, OtpRequest, extract_otp, imap_otp_handler, otp_tool
+from hai_agents_tools.otp import _html_to_text
+
+
+def test_otp_tool_definition_defaults() -> None:
+    t = otp_tool()
+    definition = t.definition()
+    assert definition["name"] == "request_otp"
+    assert "one-time password" in definition["description"]
+    schema = definition["input_schema"]
+    assert schema["type"] == "object"
+    assert schema["required"] == ["prompt"]
+    assert set(schema["properties"]) == {"prompt", "kind", "source"}
+    assert schema["properties"]["kind"]["enum"] == ["code", "link"]
+
+
+def test_otp_tool_custom_handler_receives_request_and_trims() -> None:
+    seen: list[OtpRequest] = []
+
+    def handler(request: OtpRequest) -> str:
+        seen.append(request)
+        return "  123456  "
+
+    t = otp_tool(handler)
+    assert t.fn(prompt="Enter the code sent to a@b.com", kind="code", source="email") == "123456"
+    assert seen == [OtpRequest(prompt="Enter the code sent to a@b.com", kind="code", source="email")]
+
+
+def test_otp_tool_defaults_kind_and_source() -> None:
+    seen: list[OtpRequest] = []
+
+    def handler(request: OtpRequest) -> str:
+        seen.append(request)
+        return "ok"
+
+    otp_tool(handler).fn(prompt="Enter the code")
+    assert seen == [OtpRequest(prompt="Enter the code", kind="code", source=None)]
+
+
+def test_otp_tool_empty_value_raises() -> None:
+    t = otp_tool(lambda request: "   ")
+    with pytest.raises(ValueError, match="No code"):
+        t.fn(prompt="Enter the code")
+    t = otp_tool(lambda request: "")
+    with pytest.raises(ValueError, match="No link"):
+        t.fn(prompt="Open the link", kind="link")
+
+
+def test_otp_tool_async_handler() -> None:
+    async def handler(request: OtpRequest) -> str:
+        return " 654321 "
+
+    result = otp_tool(handler).fn(prompt="Enter the code")
+    assert asyncio.run(_await(result)) == "654321"
+
+
+async def _await(value: Awaitable[str]) -> str:
+    return await value
+
+
+def test_otp_tool_default_handler_prompts_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    prompts: list[str] = []
+
+    def fake_input(prompt: str) -> str:
+        prompts.append(prompt)
+        return "42"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    assert otp_tool().fn(prompt="Enter the 6-digit code", source="sms") == "42"
+    assert prompts == ["Enter the 6-digit code (sent via sms)\nEnter the code: "]
+
+
+def test_otp_tool_name_and_description_overrides() -> None:
+    t = otp_tool(lambda request: "x", name="get_2fa_code", description="Fetch the 2FA code.")
+    assert t.definition() == {
+        "name": "get_2fa_code",
+        "description": "Fetch the 2FA code.",
+        "input_schema": OTP_TOOL_INPUT_SCHEMA,
+    }
+
+
+def test_extract_otp_code_near_keyword() -> None:
+    assert extract_otp("Your verification code is 482913. It expires in 10 minutes.") == "482913"
+    assert extract_otp("Your OTP code is 1234") == "1234"
+
+
+def test_extract_otp_grouped_digits() -> None:
+    assert extract_otp("Enter 123 456 to continue") == "123 456"
+    assert extract_otp("Your code is 1234-5678") == "1234-5678"
+    assert extract_otp("Use 123 456 789 now") == "123 456 789"
+
+
+def test_extract_otp_collapses_whitespace_from_html_layouts() -> None:
+    # Table-based HTML mail turns into text with the code far from the keyword.
+    text = "Your verification code\n\n\n" + " " * 50 + "\n\n482913"
+    assert extract_otp(text) == "482913"
+
+
+def test_extract_otp_alphanumeric_code() -> None:
+    assert extract_otp("Use passcode 7GK4-P2Q to continue.") == "7GK4-P2Q"
+
+
+def test_extract_otp_bare_digits_fallback() -> None:
+    assert extract_otp("314159 is your Acme sign-in key") == "314159"
+
+
+def test_extract_otp_custom_pattern_capture_group() -> None:
+    assert extract_otp("Ticket ABC-99-XYZ opened", code_pattern=re.compile(r"Ticket ([A-Z0-9-]+)")) == "ABC-99-XYZ"
+
+
+def test_extract_otp_link_prefers_verification_url() -> None:
+    text = "View in browser: https://news.example.com/open?id=1 Confirm: https://app.example.com/verify?token=abc"
+    assert extract_otp(text, kind="link") == "https://app.example.com/verify?token=abc"
+
+
+def test_extract_otp_link_hint_ignores_embedded_words() -> None:
+    # "authors" / "hotpicks" must not trip the "auth" / "otp" hints and outrank the real link.
+    text = (
+        "Meet our team: https://blog.example.com/authors/jane "
+        "Deals: https://shop.example.com/hotpicks "
+        "Confirm your account: https://app.example.com/verify?id=1"
+    )
+    assert extract_otp(text, kind="link") == "https://app.example.com/verify?id=1"
+
+
+def test_extract_otp_link_hint_still_matches_auth_segments() -> None:
+    text = "Docs: https://docs.example.com/start Login: https://id.example.com/auth/callback?sid=9"
+    assert extract_otp(text, kind="link") == "https://id.example.com/auth/callback?sid=9"
+    text = "Docs: https://docs.example.com/start Login: https://oauth.example.com/approve?sid=9"
+    assert extract_otp(text, kind="link") == "https://oauth.example.com/approve?sid=9"
+
+
+def test_extract_otp_link_falls_back_to_first_url() -> None:
+    assert extract_otp("See https://example.com/a then https://example.com/b", kind="link") == "https://example.com/a"
+
+
+def test_extract_otp_no_match_returns_none() -> None:
+    assert extract_otp("Hello there, nothing to see.") is None
+    assert extract_otp("Hello there, nothing to see.", kind="link") is None
+
+
+def test_html_to_text_surfaces_hrefs_and_entities() -> None:
+    text = _html_to_text(
+        '<style>.x{color:red}</style><p>Click <a href="https://x.test/verify?t=1">here</a>&nbsp;to verify</p>'
+    )
+    assert "https://x.test/verify?t=1" in text
+    assert "to verify" in text
+    assert "color:red" not in text
+
+
+class _FakeImapConn:
+    """Two unread messages; only the newest (id 2) carries a code."""
+
+    last: "_FakeImapConn"
+
+    def __init__(self, host: str, port: int) -> None:
+        type(self).last = self
+        self.host, self.port = host, port
+        self.stored: list = []
+        self.searches: list = []
+        self.logged_out = False
+
+    def login(self, username: str, password: str) -> None:
+        self.credentials = (username, password)
+
+    def select(self, mailbox: str) -> None:
+        self.mailbox = mailbox
+
+    def search(self, charset, *criteria):  # type: ignore[no-untyped-def]
+        self.searches.append(criteria)
+        return "OK", [b"1 2"]
+
+    def fetch(self, msg_id, spec):  # type: ignore[no-untyped-def]
+        bodies = {
+            b"1": b"Subject: Welcome\r\nContent-Type: text/plain\r\n\r\nThanks for signing up!\r\n",
+            b"2": b"Subject: Your login code\r\nContent-Type: text/plain\r\n\r\nYour login code is 314159.\r\n",
+        }
+        return "OK", [(msg_id + b" (BODY[] {0}", bodies[msg_id]), b")"]
+
+    def store(self, msg_id, op, flags):  # type: ignore[no-untyped-def]
+        self.stored.append((msg_id, op, flags))
+
+    def logout(self) -> None:
+        self.logged_out = True
+
+
+def test_imap_otp_handler_reads_newest_unread_and_marks_seen(monkeypatch: pytest.MonkeyPatch) -> None:
+    import imaplib
+
+    monkeypatch.setattr(imaplib, "IMAP4_SSL", _FakeImapConn)
+    handler = imap_otp_handler(host="imap.test", username="u@test", password="pw", sender="no-reply@x.test")
+    assert handler(OtpRequest(prompt="Enter the code")) == "314159"
+    conn = _FakeImapConn.last
+    assert conn.credentials == ("u@test", "pw")
+    assert conn.searches == [("UNSEEN", "FROM", '"no-reply@x.test"')]
+    assert conn.stored == [(b"2", "+FLAGS", "\\Seen")]
+    assert conn.logged_out
+
+
+def test_imap_otp_handler_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    import imaplib
+
+    class _EmptyImapConn(_FakeImapConn):
+        def search(self, charset, *criteria):  # type: ignore[no-untyped-def]
+            return "OK", [b""]
+
+    monkeypatch.setattr(imaplib, "IMAP4_SSL", _EmptyImapConn)
+    handler = imap_otp_handler(host="imap.test", username="u@test", password="pw", timeout_s=0)
+    with pytest.raises(TimeoutError, match="No code found"):
+        handler(OtpRequest(prompt="Enter the code"))
+    assert _EmptyImapConn.last.logged_out

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -211,6 +211,22 @@ def test_imap_otp_handler_reads_newest_unread_and_marks_seen(monkeypatch: pytest
     assert conn.logged_out
 
 
+def test_imap_otp_handler_skips_message_that_fails_to_fetch_or_parse(monkeypatch: pytest.MonkeyPatch) -> None:
+    import imaplib
+
+    class _BrokenNewestImapConn(_FakeImapConn):
+        def fetch(self, msg_id, spec):  # type: ignore[no-untyped-def]
+            if msg_id == b"2":
+                raise imaplib.IMAP4.error("FETCH failed")
+            body = b"Subject: Your login code\r\nContent-Type: text/plain\r\n\r\nYour login code is 271828.\r\n"
+            return "OK", [(msg_id + b" (BODY[] {0}", body), b")"]
+
+    monkeypatch.setattr(imaplib, "IMAP4_SSL", _BrokenNewestImapConn)
+    handler = imap_otp_handler(host="imap.test", username="u@test", password="pw")
+    assert handler(OtpRequest(prompt="Enter the code")) == "271828"
+    assert _BrokenNewestImapConn.last.stored == [(b"1", "+FLAGS", "\\Seen")]
+
+
 def test_imap_otp_handler_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
     import imaplib
 

--- a/tests/test_tools_package.py
+++ b/tests/test_tools_package.py
@@ -1,0 +1,45 @@
+"""Meta checks for ``hai_agents_tools``, generic over every prebuilt tool module.
+
+Each tool module must declare ``__all__`` and have every name in it re-exported,
+object for object, by the package ``__init__``. New tool modules are discovered from
+the package directory automatically; adding one requires no test changes here.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+import pytest
+
+import hai_agents_tools
+
+
+def _tool_module_names() -> list[str]:
+    """Names of the prebuilt tool modules, discovered from the package directory."""
+    return sorted(module.name for module in pkgutil.iter_modules(hai_agents_tools.__path__))
+
+
+def test_at_least_one_tool_module_is_discovered() -> None:
+    assert "otp" in _tool_module_names()
+
+
+@pytest.mark.parametrize("module_name", _tool_module_names())
+def test_tool_module_declares_all(module_name: str) -> None:
+    module = importlib.import_module(f"hai_agents_tools.{module_name}")
+    assert getattr(module, "__all__", None), f"{module_name} must declare a non-empty __all__"
+
+
+@pytest.mark.parametrize("module_name", _tool_module_names())
+def test_tool_module_reexported_by_package(module_name: str) -> None:
+    module = importlib.import_module(f"hai_agents_tools.{module_name}")
+    for name in module.__all__:
+        assert name in hai_agents_tools.__all__, f"{name} missing from hai_agents_tools __all__"
+        assert getattr(hai_agents_tools, name) is getattr(module, name), (
+            f"{name} re-export does not match {module_name}"
+        )
+
+
+def test_package_all_names_resolve() -> None:
+    for name in hai_agents_tools.__all__:
+        assert getattr(hai_agents_tools, name, None) is not None, f"__all__ lists unknown name {name}"


### PR DESCRIPTION
## feat: prebuilt OTP tool
Adds a hand-written `hai_agents_tools` package with prebuilt custom tools,
starting with an OTP tool for logins that need two-factor codes.
### What's new
- **`otp_tool`** — a ready-made custom tool the agent calls when a login,
  signup, or verification step asks for a one-time password, verification
  code, or confirmation link. The handler resolves the value: interactively
  on stdin by default, or programmatically (inbox API, Slack prompt, ...).
- **`imap_otp_handler`** — a handler that polls a mailbox over IMAP for
  unread messages (newest first, optionally filtered by sender), extracts
  the code or link, and marks the matched message read so a retry cannot
  reuse a stale code. Works with any IMAP server; for Gmail use an app
  password.
- **`extract_otp`** — best-effort extraction heuristics for codes
  (keyword-proximity, grouped digits, alphanumeric tokens, custom pattern
  override) and confirmation links (verification-looking URLs preferred).
```python
from hai_agents import Client
from hai_agents_tools import imap_otp_handler, otp_tool
handler = imap_otp_handler(
    host="imap.gmail.com",
    username="agent-inbox@gmail.com",
    password=os.environ["GMAIL_APP_PASSWORD"],
)
result = Client().run_session(
    agent="h/web-surfer-pro",
    messages="Log in to example.com",
    tools=[otp_tool(handler)],
)
```
Privacy: like every custom tool, the handler runs entirely in your process. IMAP credentials never leave your machine; the agent only receives the single extracted code or link — never mailbox contents.

Structure
hai_agents_tools is hand-written and maintained in this repository (like hai_agents_cli and hai_agents_local), outside the regenerated hai_agents tree. It builds on the tool plumbing (Tool, tool, as_tools) that ships with the generated package and ships in the same wheel, with a py.typed marker.

Tests
tests/test_otp.py — tool definition, handler contract (trimming, empty values, async handlers, stdin fallback), extraction heuristics, and an IMAP handler test against a fake connection (newest-unread selection, mark-seen, timeout).
tests/test_tools_package.py — meta checks: every tool module declares __all__ and is re-exported, object for object, by the package init; new tool modules are discovered automatically.
README gains a "Prebuilt: one-time passwords (2FA)" section.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds mailbox/IMAP credential handling and OTP extraction used during automated logins; credentials stay in-process but misuse or weak mailbox isolation could leak codes if misconfigured.
> 
> **Overview**
> Introduces a new **`hai_agents_tools`** package (included in the same wheel via `pyproject.toml`) with prebuilt custom tools for agent sessions, starting with **2FA / OTP**.
> 
> **`otp_tool`** exposes a `request_otp` tool the agent can call during login or verification. Handlers are pluggable: default **stdin** prompting, or **`imap_otp_handler`** which polls unread IMAP mail (newest first, optional sender filter, age limits), extracts a code or confirmation link via **`extract_otp`**, marks the message read, and returns only that value to the agent.
> 
> README documents the 2FA flow and local-only credential handling. **`tests/test_otp.py`** covers tool contract, extraction heuristics, and fake-IMAP behavior; **`tests/test_tools_package.py`** enforces package re-exports for future tool modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca8c0deae619595c7008a73eb6305e370acf5dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->