### PR TITLE
chore(sdk): sync generated SDK (v1.0.7)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7054,6 +7054,34 @@
             "title": "Idle Timeout S",
             "description": "Seconds to keep the session open for follow-up messages after each answer. Null ends the session as soon as the agent answers."
           },
+          "delete_after_min": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Delete After Min",
+            "description": "Minutes after the session finishes before it is automatically deleted. Defaults to 30 days. Null keeps the session forever.",
+            "default": 43200
+          },
+          "delete_screenshot_after_min": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Delete Screenshot After Min",
+            "description": "Minutes after the session finishes before its screenshots are deleted. Defaults to 30 days. Null keeps screenshots for the session's lifetime.",
+            "default": 43200
+          },
           "queue": {
             "type": "boolean",
             "title": "Queue",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hai-agents"
-version = "1.0.6"
+version = "1.0.7"
 description = "Python SDK for H Company's Computer-Use Agents: autonomous agents powered by Holo."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/hai_agents/core/client_wrapper.py
+++ b/src/hai_agents/core/client_wrapper.py
@@ -29,9 +29,9 @@ class BaseClientWrapper:
         import platform
 
         headers: typing.Dict[str, str] = {
-            "User-Agent": "hai_agents/1.0.6",
+            "User-Agent": "hai_agents/1.0.7",
             "X-HCompany-Client-Name": "hai_agents",
-            "X-HCompany-Client-Version": "1.0.6",
+            "X-HCompany-Client-Version": "1.0.7",
             "X-HCompany-Client-Type": "sdk",
             "X-HCompany-Language": "Python",
             "X-HCompany-Runtime": f"python/{platform.python_version()}",

--- a/src/hai_agents/polling.py
+++ b/src/hai_agents/polling.py
@@ -283,7 +283,8 @@ async def _async_execute_tool_call(
         result = f"Tool {name!r} is not registered with this client."
     else:
         try:
-            result = local_tool.fn(**(call.get("args") or {}))
+            args = call.get("args") or {}
+            result = await asyncio.get_running_loop().run_in_executor(None, lambda: local_tool.fn(**args))
             if inspect.isawaitable(result):
                 result = await result
         except Exception as exc:

--- a/src/hai_agents/sessions/client.py
+++ b/src/hai_agents/sessions/client.py
@@ -143,6 +143,8 @@ class SessionsClient:
         max_steps: typing.Optional[int] = OMIT,
         max_time_s: typing.Optional[float] = OMIT,
         idle_timeout_s: typing.Optional[int] = OMIT,
+        delete_after_min: typing.Optional[int] = OMIT,
+        delete_screenshot_after_min: typing.Optional[int] = OMIT,
         queue: typing.Optional[bool] = OMIT,
         group_id: typing.Optional[str] = OMIT,
         parent_session_id: typing.Optional[str] = OMIT,
@@ -170,6 +172,12 @@ class SessionsClient:
 
         idle_timeout_s : typing.Optional[int]
             Seconds to keep the session open for follow-up messages after each answer. Null ends the session as soon as the agent answers.
+
+        delete_after_min : typing.Optional[int]
+            Minutes after the session finishes before it is automatically deleted. Defaults to 30 days. Null keeps the session forever.
+
+        delete_screenshot_after_min : typing.Optional[int]
+            Minutes after the session finishes before its screenshots are deleted. Defaults to 30 days. Null keeps screenshots for the session's lifetime.
 
         queue : typing.Optional[bool]
             When the organization is at its concurrent-session limit, accept this session into a queue (status 'queued') instead of rejecting it with 429. Queued sessions start automatically, oldest first, as running sessions finish. Set to false to get an immediate 429 when no slot is available.
@@ -209,6 +217,8 @@ class SessionsClient:
             max_steps=max_steps,
             max_time_s=max_time_s,
             idle_timeout_s=idle_timeout_s,
+            delete_after_min=delete_after_min,
+            delete_screenshot_after_min=delete_screenshot_after_min,
             queue=queue,
             group_id=group_id,
             parent_session_id=parent_session_id,
@@ -920,6 +930,8 @@ class AsyncSessionsClient:
         max_steps: typing.Optional[int] = OMIT,
         max_time_s: typing.Optional[float] = OMIT,
         idle_timeout_s: typing.Optional[int] = OMIT,
+        delete_after_min: typing.Optional[int] = OMIT,
+        delete_screenshot_after_min: typing.Optional[int] = OMIT,
         queue: typing.Optional[bool] = OMIT,
         group_id: typing.Optional[str] = OMIT,
         parent_session_id: typing.Optional[str] = OMIT,
@@ -947,6 +959,12 @@ class AsyncSessionsClient:
 
         idle_timeout_s : typing.Optional[int]
             Seconds to keep the session open for follow-up messages after each answer. Null ends the session as soon as the agent answers.
+
+        delete_after_min : typing.Optional[int]
+            Minutes after the session finishes before it is automatically deleted. Defaults to 30 days. Null keeps the session forever.
+
+        delete_screenshot_after_min : typing.Optional[int]
+            Minutes after the session finishes before its screenshots are deleted. Defaults to 30 days. Null keeps screenshots for the session's lifetime.
 
         queue : typing.Optional[bool]
             When the organization is at its concurrent-session limit, accept this session into a queue (status 'queued') instead of rejecting it with 429. Queued sessions start automatically, oldest first, as running sessions finish. Set to false to get an immediate 429 when no slot is available.
@@ -994,6 +1012,8 @@ class AsyncSessionsClient:
             max_steps=max_steps,
             max_time_s=max_time_s,
             idle_timeout_s=idle_timeout_s,
+            delete_after_min=delete_after_min,
+            delete_screenshot_after_min=delete_screenshot_after_min,
             queue=queue,
             group_id=group_id,
             parent_session_id=parent_session_id,

--- a/src/hai_agents/sessions/raw_client.py
+++ b/src/hai_agents/sessions/raw_client.py
@@ -167,6 +167,8 @@ class RawSessionsClient:
         max_steps: typing.Optional[int] = OMIT,
         max_time_s: typing.Optional[float] = OMIT,
         idle_timeout_s: typing.Optional[int] = OMIT,
+        delete_after_min: typing.Optional[int] = OMIT,
+        delete_screenshot_after_min: typing.Optional[int] = OMIT,
         queue: typing.Optional[bool] = OMIT,
         group_id: typing.Optional[str] = OMIT,
         parent_session_id: typing.Optional[str] = OMIT,
@@ -194,6 +196,12 @@ class RawSessionsClient:
 
         idle_timeout_s : typing.Optional[int]
             Seconds to keep the session open for follow-up messages after each answer. Null ends the session as soon as the agent answers.
+
+        delete_after_min : typing.Optional[int]
+            Minutes after the session finishes before it is automatically deleted. Defaults to 30 days. Null keeps the session forever.
+
+        delete_screenshot_after_min : typing.Optional[int]
+            Minutes after the session finishes before its screenshots are deleted. Defaults to 30 days. Null keeps screenshots for the session's lifetime.
 
         queue : typing.Optional[bool]
             When the organization is at its concurrent-session limit, accept this session into a queue (status 'queued') instead of rejecting it with 429. Queued sessions start automatically, oldest first, as running sessions finish. Set to false to get an immediate 429 when no slot is available.
@@ -228,6 +236,8 @@ class RawSessionsClient:
                 "max_steps": max_steps,
                 "max_time_s": max_time_s,
                 "idle_timeout_s": idle_timeout_s,
+                "delete_after_min": delete_after_min,
+                "delete_screenshot_after_min": delete_screenshot_after_min,
                 "queue": queue,
                 "group_id": group_id,
                 "parent_session_id": parent_session_id,
@@ -1284,6 +1294,8 @@ class AsyncRawSessionsClient:
         max_steps: typing.Optional[int] = OMIT,
         max_time_s: typing.Optional[float] = OMIT,
         idle_timeout_s: typing.Optional[int] = OMIT,
+        delete_after_min: typing.Optional[int] = OMIT,
+        delete_screenshot_after_min: typing.Optional[int] = OMIT,
         queue: typing.Optional[bool] = OMIT,
         group_id: typing.Optional[str] = OMIT,
         parent_session_id: typing.Optional[str] = OMIT,
@@ -1311,6 +1323,12 @@ class AsyncRawSessionsClient:
 
         idle_timeout_s : typing.Optional[int]
             Seconds to keep the session open for follow-up messages after each answer. Null ends the session as soon as the agent answers.
+
+        delete_after_min : typing.Optional[int]
+            Minutes after the session finishes before it is automatically deleted. Defaults to 30 days. Null keeps the session forever.
+
+        delete_screenshot_after_min : typing.Optional[int]
+            Minutes after the session finishes before its screenshots are deleted. Defaults to 30 days. Null keeps screenshots for the session's lifetime.
 
         queue : typing.Optional[bool]
             When the organization is at its concurrent-session limit, accept this session into a queue (status 'queued') instead of rejecting it with 429. Queued sessions start automatically, oldest first, as running sessions finish. Set to false to get an immediate 429 when no slot is available.
@@ -1345,6 +1363,8 @@ class AsyncRawSessionsClient:
                 "max_steps": max_steps,
                 "max_time_s": max_time_s,
                 "idle_timeout_s": idle_timeout_s,
+                "delete_after_min": delete_after_min,
+                "delete_screenshot_after_min": delete_screenshot_after_min,
                 "queue": queue,
                 "group_id": group_id,
                 "parent_session_id": parent_session_id,

--- a/src/hai_agents/types/session_request.py
+++ b/src/hai_agents/types/session_request.py
@@ -40,6 +40,16 @@ class SessionRequest(UniversalBaseModel):
     Seconds to keep the session open for follow-up messages after each answer. Null ends the session as soon as the agent answers.
     """
 
+    delete_after_min: typing.Optional[int] = pydantic.Field(default=None)
+    """
+    Minutes after the session finishes before it is automatically deleted. Defaults to 30 days. Null keeps the session forever.
+    """
+
+    delete_screenshot_after_min: typing.Optional[int] = pydantic.Field(default=None)
+    """
+    Minutes after the session finishes before its screenshots are deleted. Defaults to 30 days. Null keeps screenshots for the session's lifetime.
+    """
+
     queue: typing.Optional[bool] = pydantic.Field(default=None)
     """
     When the organization is at its concurrent-session limit, accept this session into a queue (status 'queued') instead of rejecting it with 429. Queued sessions start automatically, oldest first, as running sessions finish. Set to false to get an immediate 429 when no slot is available.

--- a/uv.lock
+++ b/uv.lock
@@ -144,7 +144,7 @@ wheels = [
 
 [[package]]
 name = "hai-agents"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Auto-generated from the upstream codegen home.

**Version:** `1.0.7` (patch; every sync bumps +0.0.1)
**Upstream:** agent_platform@b465068